### PR TITLE
Add virtual Menu class and reference child implementation

### DIFF
--- a/Encore/include/game/audio.h
+++ b/Encore/include/game/audio.h
@@ -46,6 +46,7 @@ public:
 	// Load and play samples
 	void loadSample(const std::string& path, const std::string& name);
 	void playSample(const std::string& name, float volume);
+	void unloadSample(const std::string& name);
 
 private:
 	std::unordered_map<std::string, unsigned int> samples; // Loaded audio samples

--- a/Encore/include/game/menus/gameMenu.h
+++ b/Encore/include/game/menus/gameMenu.h
@@ -16,14 +16,13 @@ enum Screens {
     RESULTS,
     SETTINGS,
     CALIBRATION,
-    CHART_LOADING_SCREEN
+    CHART_LOADING_SCREEN,
+    SOUND_TEST
 };
 
-class Menu {
+class GameMenu {
 private:
 
-
-    Menu() {}
 
     template<typename CharT>
     struct Separators : public std::numpunct<CharT>
@@ -44,15 +43,12 @@ private:
     void renderPlayerResults(Player player, Song song);
     void renderStars(Player player, float xPos, float yPos, float scale, bool left);
 public:
+    GameMenu() {}
 
     void DrawTopOvershell(float TopOvershell);
     void DrawBottomOvershell();
     void DrawBottomBottomOvershell();
 
-    static Menu& getInstance() {
-        static Menu instance; // This is the single instance
-        return instance;
-    }
     void DrawFPS(int posX, int posY);
     bool hehe = false;
     Song ChosenSong;
@@ -65,8 +61,7 @@ public:
     Texture2D AlbumArtBackground;
     bool albumArtLoaded = false;
     void showResults(Player &player);
-    void loadMenu(GLFWgamepadstatefun gamepadStateCallbackSetControls);
-    inline void loadTitleScreen() {};
+    void loadMainMenu(GLFWgamepadstatefun gamepadStateCallbackSetControls);
 
     void SwitchScreen(Screens screen);
     void DrawAlbumArtBackground(Texture2D song);
@@ -75,4 +70,4 @@ public:
     void DrawVersion();
 };
 
-
+extern GameMenu TheGameMenu;

--- a/Encore/include/game/menus/menu.h
+++ b/Encore/include/game/menus/menu.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class Menu {
+    public:
+    Menu() {}
+    virtual ~Menu() {}
+
+    virtual void Draw() = 0; // NOTE: requires BeginDrawing() to have already been called
+    virtual void Load() = 0;
+    static bool onNewMenu;
+};
+
+extern Menu* ActiveMenu;

--- a/Encore/include/game/menus/sndTestMenu.h
+++ b/Encore/include/game/menus/sndTestMenu.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "raylib.h"
+
+#include "game/menus/menu.h"
+
+class SoundTestMenu : public Menu {
+    std::vector<std::string> mSoundIds;
+    Font mFont;
+    public:
+    SoundTestMenu();
+    virtual ~SoundTestMenu();
+
+    virtual void Draw();
+    virtual void Load();
+
+};

--- a/Encore/src/game/audio.cpp
+++ b/Encore/src/game/audio.cpp
@@ -1,4 +1,5 @@
 #include "game/audio.h"
+#include "bass/bass.h"
 #include "bass/bassopus.h"
 #include "GLFW/glfw3.h"
 
@@ -146,6 +147,16 @@ void AudioManager::playSample(const std::string& name, float volume) {
         HCHANNEL channel = BASS_SampleGetChannel(it->second, false);
         BASS_ChannelSetAttribute(channel, BASS_ATTRIB_VOL, volume);
         BASS_ChannelPlay(channel, true);
+    } else {
+        std::cerr << "Sample not found: " << name << std::endl;
+    }
+}
+
+void AudioManager::unloadSample(const std::string& name) {
+    auto it = samples.find(name);
+    if (it != samples.end()) {
+        BASS_SampleFree(it->second);
+        samples.erase(it);
     } else {
         std::cerr << "Sample not found: " << name << std::endl;
     }

--- a/Encore/src/game/gameplay/gameplayRenderer.cpp
+++ b/Encore/src/game/gameplay/gameplayRenderer.cpp
@@ -14,7 +14,7 @@
 Assets &gprAssets = Assets::getInstance();
 Settings& gprSettings = Settings::getInstance();
 AudioManager &gprAudioManager = AudioManager::getInstance();
-Menu& gprMenu = Menu::getInstance();
+GameMenu& gprMenu = TheGameMenu;
 Units& gprU = Units::getInstance();
 
 

--- a/Encore/src/game/menus/sndTestMenu.cpp
+++ b/Encore/src/game/menus/sndTestMenu.cpp
@@ -1,0 +1,45 @@
+#include "game/menus/sndTestMenu.h"
+#include "game/audio.h"
+#include "game/menus/gameMenu.h"
+#include "game/menus/uiUnits.h"
+#include "raylib.h"
+#include "raygui.h"
+#include <filesystem>
+
+auto& TheAudioMgr = AudioManager::getInstance();
+
+SoundTestMenu::SoundTestMenu() {}
+
+SoundTestMenu::~SoundTestMenu() {
+    for (auto snd : mSoundIds) { TheAudioMgr.unloadSample(snd); }
+}
+
+void SoundTestMenu::Draw() {
+    static int selectedSound;
+    Units u = Units::getInstance();
+    DrawRectangle(0,0,GetScreenWidth(),GetScreenHeight(), BLACK);
+    DrawTextEx(mFont, "SOUND TEST", {u.wpct(0.33), u.hpct(0.2)}, u.hinpct(0.1), 0, WHITE);
+    DrawTextEx(mFont, mSoundIds[selectedSound].c_str(), {u.wpct(0.33), u.hpct(0.8)}, u.hinpct(0.1), 0, WHITE);
+
+    if (GuiButton({u.wpct(0.35), u.hpct(0.4), u.winpct(0.04), u.hinpct(0.2)}, "-")) { selectedSound--; }
+    if (GuiButton({u.wpct(0.4), u.hpct(0.4), u.winpct(0.2), u.hinpct(0.2)}, "Play sound")) {
+        TheAudioMgr.playSample(mSoundIds[selectedSound], 0.8f);
+    }
+    if (GuiButton({u.wpct(0.61), u.hpct(0.4), u.winpct(0.04), u.hinpct(0.2)}, "+")) { selectedSound++; }
+
+    if (GuiButton({0,0, u.winpct(0.3),u.hinpct(0.15)}, "Return")) TheGameMenu.SwitchScreen(MENU);
+
+    if (selectedSound < 0) selectedSound = mSoundIds.size() - 1;
+    if (selectedSound > mSoundIds.size() - 1) selectedSound = 0;
+}
+
+void SoundTestMenu::Load() {
+    std::filesystem::path assetsdir = GetApplicationDirectory();
+    assetsdir /= "Assets";
+    mFont = LoadFont((assetsdir / "fonts/Rubik-Regular.ttf").c_str());
+    
+    mSoundIds.push_back(std::string("combobreak"));
+    TheAudioMgr.loadSample(assetsdir / "combobreak.mp3", "combobreak");
+    mSoundIds.push_back(std::string("kick"));
+    TheAudioMgr.loadSample(assetsdir / "kick.wav", "kick");
+}


### PR DESCRIPTION
This will be the first of several rearchitecturing PRs, as every menu's drawing routines will need to migrate to this system. Additionally, the original `Menu` from `gameMenu.h` has been renamed to `GameMenu` to appear clearer in function, and its `getInstance` method has been replaced with a global scope singleton.