### PR TITLE
Fix CMake warnings

### DIFF
--- a/Encore/CMakeLists.txt
+++ b/Encore/CMakeLists.txt
@@ -21,9 +21,8 @@ if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   FetchContent_GetProperties(raylib)
   if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
     set(FETCHCONTENT_QUIET NO)
-    FetchContent_Populate(raylib)
+    FetchContent_MakeAvailable(raylib)
     set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-    add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
   endif()
 endif()
 
@@ -37,8 +36,7 @@ if (NOT json_FOUND)
   FetchContent_GetProperties(json)
   if (NOT json_POPULATED)
     set(FETCHCONTENT_QUIET NO)
-    FetchContent_Populate(json)
-    add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR})
+    FetchContent_MakeAvailable(json)
   endif()
 endif()
 


### PR DESCRIPTION
Per the warning, `FetchContent_Populate` is deprecated in favor of `FetchContent_MakeAvailable`.