### PR TITLE
Greatly clean up `SongList`

### DIFF
--- a/Encore/CMakeLists.txt
+++ b/Encore/CMakeLists.txt
@@ -111,9 +111,6 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
         "-DENCORE_VERSION=\"v0.2.0\"")
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
-        "-DCACHE_VERSION=3")
-
-target_compile_definitions(${PROJECT_NAME} PRIVATE
         "-DGIT_BRANCH=\"${GIT_BRANCH}\"")
 
 target_link_libraries(Encore raylib nlohmann_json::nlohmann_json ${BASS} ${BASSOPUS})

--- a/Encore/src/main.cpp
+++ b/Encore/src/main.cpp
@@ -113,7 +113,7 @@ SongList &songList = SongList::getInstance();
 Assets &assets = Assets::getInstance();
 
 
-int currentSortValue = 0;
+SortType currentSortValue = SortType::Title;
 std::vector<std::string> sortTypes{"Title", "Artist", "Length"};
 
 static void DrawTextRubik(const char *text, float posX, float posY, float fontSize, Color color) {
@@ -1173,7 +1173,7 @@ int main(int argc, char *argv[]) {
 			case MENU: {
 				if (!menu.songsLoaded) {
 					if (std::filesystem::exists("songCache.encr")) {
-						songList = songList.LoadCache(settingsMain.songPaths);
+						songList.LoadCache(settingsMain.songPaths);
 						menu.songsLoaded = true;
 					}
 				}
@@ -2097,7 +2097,7 @@ int main(int argc, char *argv[]) {
 			}
 			case SONG_SELECT: {
 				if (!menu.songsLoaded) {
-					songList = songList.LoadCache(settingsMain.songPaths);
+					songList.LoadCache(settingsMain.songPaths);
 					menu.songsLoaded = true;
 				}
 				streamsLoaded = false;
@@ -2190,7 +2190,7 @@ int main(int argc, char *argv[]) {
 
 
 				DrawTextEx(assets.josefinSansItalic,
-							TextFormat("Sorted by: %s", sortTypes[currentSortValue].c_str()), {
+							TextFormat("Sorted by: %s", sortTypes[(int)currentSortValue].c_str()), {
 								u.LeftSide,
 								u.hinpct(0.165f)
 							}, u.hinpct(0.03f), 0, WHITE);
@@ -2320,7 +2320,7 @@ int main(int argc, char *argv[]) {
 				if (songSelectOffset > 0 ) {
 					std::string SongTitleForCharThingyThatsTemporary = songList.listMenuEntries[songSelectOffset].headerChar;
 					switch (currentSortValue) {
-						case 0: {
+						case SortType::Title: {
 							if (songList.listMenuEntries[songSelectOffset].isHeader) {
 								SongTitleForCharThingyThatsTemporary = songList.songs[songList.listMenuEntries[songSelectOffset-1].songListID].title[0];
 							} else {
@@ -2328,7 +2328,7 @@ int main(int argc, char *argv[]) {
 							}
 							break;
 						}
-						case 1: {
+						case SortType::Artist: {
 							if (songList.listMenuEntries[songSelectOffset].isHeader) {
 								SongTitleForCharThingyThatsTemporary = songList.songs[songList.listMenuEntries[songSelectOffset-1].songListID].artist[0];
 							} else {
@@ -2336,7 +2336,7 @@ int main(int argc, char *argv[]) {
 							}
 							break;
 						}
-						case 2: {
+						case SortType::Length: {
 							if (songList.listMenuEntries[songSelectOffset].isHeader) {
 								SongTitleForCharThingyThatsTemporary = std::to_string(songList.songs[songList.listMenuEntries[songSelectOffset-1].songListID].length);
 							} else {
@@ -2491,8 +2491,7 @@ int main(int argc, char *argv[]) {
 								GetScreenHeight() - u.hpct(0.1475f), u.winpct(0.2f),
 								u.hinpct(0.05f)
 							}, "Sort")) {
-					currentSortValue++;
-					if (currentSortValue == 3) currentSortValue = 0;
+					currentSortValue = NextSortType(currentSortValue);
 					if (selSong)
 						songList.sortList(currentSortValue, curPlayingSong);
 					else

--- a/Encore/src/song/songlist.h
+++ b/Encore/src/song/songlist.h
@@ -1,12 +1,45 @@
 #pragma once
-#include "song.h"
-#include <vector>
-#include <filesystem>
-#include <thread>
 #include <algorithm>
+#include <filesystem>
 #include <set>
+#include <thread>
+#include <vector>
+
 #include "picosha2.h"
 #include "raylib.h"
+
+#include "song/song.h"
+
+// Version is formatted as YY_MM_DD_RR, where:
+// - YY: Current year (2 digits, 4 digits impedes on 32-bit integer limit)
+// - MM: Current month
+// - DD: Current day
+// - RR: Number of times the cache was revised that day, starting from 1
+#define SONG_CACHE_VERSION 24'08'31'01
+#define SONG_CACHE_HEADER 'ENCR'
+
+enum class SortType : int {
+    EnumStart = 0,
+
+    Title = 0,
+    Artist,
+    Length,
+
+    EnumEnd
+};
+
+// Enums don't have built-in operator++, and we also need wrapping,
+// so we can combine both into one function
+inline SortType NextSortType(SortType current) {
+    int underlying = static_cast<int>(current);
+    current = static_cast<SortType>(++underlying);
+
+    if (current >= SortType::EnumEnd) {
+        current = SortType::EnumStart;
+    }
+
+    return current;
+}
 
 class SongList
 {
@@ -24,305 +57,322 @@ public:
         return instance;
     }
 
-    static bool sortArtist(const Song& a, const Song& b) {
-        return ((std::string)TextToLower(a.artist.c_str())) < ((std::string)TextToLower(b.artist.c_str()));
-    }
-    static bool sortTitle(const Song& a, const Song& b) {
-        return ((std::string)TextToLower(a.title.c_str())) < ((std::string)TextToLower(b.title.c_str()));
-    }
-    static bool sortLen(const Song& a, const Song& b) {
-        return a.length < b.length;
-    }
     std::vector<ListMenuEntry> listMenuEntries;
     std::vector<Song> songs;
     int songCount = 0;
     int directoryCount  = 0;
     int badSongCount = 0;
-    //0 - title
-    //1 - artist
-    //2 - length
-    void sortList(int sortType) {
+
+private:
+    static bool sortArtist(const Song& a, const Song& b) {
+        std::string aLower = TextToLower(a.artist.c_str());
+        std::string bLower = TextToLower(b.artist.c_str());
+        return aLower < bLower;
+    }
+
+    static bool sortTitle(const Song& a, const Song& b) {
+        std::string aLower = TextToLower(a.title.c_str());
+        std::string bLower = TextToLower(b.title.c_str());
+        return aLower < bLower;
+    }
+
+    static bool sortLen(const Song& a, const Song& b) {
+        return a.length < b.length;
+    }
+
+public:
+    void sortList(SortType sortType) {
         switch (sortType) {
-            case (0):
+            case SortType::Title:
                 std::sort(songs.begin(), songs.end(), sortTitle);
                 break;
-            case (1):
+            case SortType::Artist:
                 std::sort(songs.begin(), songs.end(), sortArtist);
                 break;
-            case (2):
+            case SortType::Length:
                 std::sort(songs.begin(), songs.end(), sortLen);
                 break;
         }
         listMenuEntries = GenerateSongEntriesWithHeaders(songs, sortType);
     }
-    void sortList(int sortType,int& selectedSong) {
-        Song curSong = songs[selectedSong];
+
+    void sortList(SortType sortType, int& selectedSong) {
+        Song& curSong = songs[selectedSong];
         selectedSong = 0;
         switch (sortType) {
-        case (0):
+        case SortType::Title:
             std::sort(songs.begin(), songs.end(), sortTitle);
             break;
-        case (1):
+        case SortType::Artist:
             std::sort(songs.begin(), songs.end(), sortArtist);
             break;
-        case (2):
+        case SortType::Length:
             std::sort(songs.begin(), songs.end(), sortLen);
             break;
         }
-        for (int i = 0; i < songs.size();i++) {
+        for (int i = 0; i < songs.size(); i++) {
             if (songs[i].artist == curSong.artist && songs[i].title == curSong.title) {
                 selectedSong = i;
+                break;
             }
         }
         listMenuEntries = GenerateSongEntriesWithHeaders(songs, sortType);
     }
 
-    void WriteCache(std::vector<Song> songs) {
+private:
+    static std::string ReadString(std::ifstream& stream) {
+        size_t length;
+        stream >> length;
+
+        std::string str(length, '\0');
+        stream.read(str.data(), str.length());
+
+        return str;
+    }
+
+    static void WriteString(std::ofstream& stream, const std::string& str) {
+        stream << (size_t)str.length();
+        stream.write(str.data(), str.length());
+    }
+
+public:
+    void WriteCache() {
         std::filesystem::remove("songCache.encr");
 
         std::ofstream SongCache("songCache.encr", std::ios::binary);
 
-        const char header[7] = "ENCORE";
-        SongCache.write(header, 6);
-        uint16_t version = CACHE_VERSION;
-        SongCache.write(reinterpret_cast<const char*>(&version), 2);
-
-        size_t SongCount = songs.size();
-        SongCache.write(reinterpret_cast<const char*>(&SongCount), sizeof(SongCount));
-
+        // Casts used to explicitly indicate type
+        SongCache << (uint32_t)SONG_CACHE_HEADER;
+        SongCache << (uint32_t)SONG_CACHE_VERSION;
+        SongCache << (size_t)songs.size();
 
         for (const auto& song : songs) {
+            WriteString(SongCache, song.songDir);
+            WriteString(SongCache, song.albumArtPath);
+            WriteString(SongCache, song.songInfoPath);
+            WriteString(SongCache, song.jsonHash);
+
+            WriteString(SongCache, song.title);
+            WriteString(SongCache, song.artist);
+
+            SongCache << song.length;
+
             TraceLog(LOG_INFO, TextFormat("%s - %s", song.title.c_str(), song.artist.c_str()));
-            size_t nameLen = song.title.size();
-            size_t songDirectoryLen = song.songDir.size();
-            size_t albumArtPathLen = song.albumArtPath.size();
-            size_t jsonPathLen = song.songInfoPath.size();
-            size_t artistLen = song.artist.size();
-            size_t lengthLen = std::to_string(song.length).size();
-
-            SongCache.write(reinterpret_cast<const char*>(&nameLen), sizeof(nameLen));
-            SongCache.write(song.title.c_str(), nameLen);
-
-            SongCache.write(reinterpret_cast<const char*>(&songDirectoryLen), sizeof(songDirectoryLen));
-            SongCache.write(song.songDir.c_str(), songDirectoryLen);
             TraceLog(LOG_INFO, TextFormat("Directory - %s", song.songDir.c_str()));
-            SongCache.write(reinterpret_cast<const char*>(&albumArtPathLen), sizeof(albumArtPathLen));
-            SongCache.write(song.albumArtPath.c_str(), albumArtPathLen);
             TraceLog(LOG_INFO, TextFormat("Album Art Path - %s", song.albumArtPath.c_str()));
-
-            SongCache.write(reinterpret_cast<const char*>(&artistLen), sizeof(artistLen));
-            SongCache.write(song.artist.c_str(), artistLen);
-
-            SongCache.write(reinterpret_cast<const char*>(&jsonPathLen), sizeof(jsonPathLen));
-            SongCache.write(song.songInfoPath.c_str(), jsonPathLen);
             TraceLog(LOG_INFO, TextFormat("Song Info Path - %s", song.songInfoPath.c_str()));
-            SongCache.write(song.jsonHash.c_str(), 64);
-
-            SongCache.write(reinterpret_cast<const char*>(&lengthLen), sizeof(lengthLen));
-            SongCache.write(std::to_string(song.length).c_str(), lengthLen);
             TraceLog(LOG_INFO, std::to_string(song.length).c_str());
         }
 
         SongCache.close();
     }
 
-
-    void ScanSongs(const std::vector<std::filesystem::path>& songsFolder)
+    static void ScanSongs(const std::vector<std::filesystem::path>& songsFolder)
     {
         SongList list;
-        for (const auto & i : songsFolder) {
-            if (std::filesystem::is_directory(i)) {
-                for (const auto &entry: std::filesystem::directory_iterator(i)) {
-                    if (std::filesystem::is_directory(entry)) {
-                        list.directoryCount++;
-                        if (std::filesystem::exists(entry.path() / "info.json")) {
-                            Song song;
-                            song.LoadSong(entry.path() / "info.json");
-                            list.songs.push_back(song);
-                            list.songCount++;
-                        }
-                        if (std::filesystem::exists(entry.path() / "song.ini")) {
-                            Song song;
 
-                            song.songInfoPath = (entry.path() / "song.ini").string();
-                            song.songDir = entry.path().string();
-                            song.LoadSongIni(entry.path());
-                            song.ini = true;
-                            list.songs.push_back(song);
-                            list.songCount++;
-                        }
-                    }
+        for (const auto &folder : songsFolder) {
+            if (!std::filesystem::is_directory(folder)) {
+                continue;
+            }
+
+            for (const auto &entry: std::filesystem::directory_iterator(folder)) {
+                if (!std::filesystem::is_directory(entry)) {
+                    continue;
+                }
+
+                list.directoryCount++;
+                if (std::filesystem::exists(entry.path() / "info.json")) {
+                    Song song;
+                    song.LoadSong(entry.path() / "info.json");
+                    list.songs.push_back(std::move(song));
+                    list.songCount++;
+                }
+                else if (std::filesystem::exists(entry.path() / "song.ini")) {
+                    Song song;
+
+                    song.songInfoPath = (entry.path() / "song.ini").string();
+                    song.songDir = entry.path().string();
+                    song.LoadSongIni(entry.path());
+                    song.ini = true;
+                    list.songs.push_back(std::move(song));
+                    list.songCount++;
                 }
             }
         }
+
         TraceLog(LOG_INFO, "Rewriting song cache");
-        WriteCache(list.songs);
+        list.WriteCache();
     }
 
-    std::vector<ListMenuEntry> GenerateSongEntriesWithHeaders(const std::vector<Song>& songs, int sortType) {
+    std::vector<ListMenuEntry> GenerateSongEntriesWithHeaders(const std::vector<Song>& songs, SortType sortType) {
         std::vector<ListMenuEntry> songEntries;
         std::string currentHeader = "";
 
         for (int i = 0; i < songs.size(); i++) {
-            Song song = songs[i];
+            const Song& song = songs[i];
             switch (sortType) {
-                case 0: {
+                case SortType::Title: {
                     if (toupper(song.title[0]) != currentHeader[0]) {
                         currentHeader = toupper(song.title[0]);
-                        songEntries.push_back({true, 0, currentHeader, false});
+                        songEntries.emplace_back(true, 0, currentHeader, false);
                     }
                     break;
                 }
-                case 1: {
+                case SortType::Artist: {
                     if (song.artist != currentHeader) {
                         currentHeader = song.artist;
-                        songEntries.push_back({true, 0, currentHeader, false});
+                        songEntries.emplace_back(true, 0, currentHeader, false);
                     }
                     break;
                 }
-                case 2: {
+                case SortType::Length: {
                     if (std::to_string(song.length) != currentHeader) {
                         currentHeader = std::to_string(song.length);
-                        songEntries.push_back({true, 0, currentHeader, false});
+                        songEntries.emplace_back(true, 0, currentHeader, false);
                     }
                     break;
                 }
             }
-            songEntries.push_back({false, i, "", false});
+            songEntries.emplace_back(false, i, "", false);
         }
 
         return songEntries;
     }
 
-    SongList LoadCache(const std::vector<std::filesystem::path>& songsFolder) {
-        SongList list;
+    void LoadCache(const std::vector<std::filesystem::path>& songsFolder) {
         std::ifstream SongCacheIn("songCache.encr", std::ios::binary);
         if (!SongCacheIn) {
             TraceLog(LOG_WARNING, "Failed to load song cache!");
-            return list;
+            return;
         }
 
+        listMenuEntries.clear();
+        songs.clear();
+        songCount = 0;
+        directoryCount = 0;
+        badSongCount = 0;
+
         // Read header
-        char header[6];
-        SongCacheIn.read(header, 6);
-        if (std::string(header, 6) != "ENCORE") {
+        uint32_t header;
+        SongCacheIn >> header;
+        if (header != SONG_CACHE_HEADER) {
             TraceLog(LOG_WARNING, "Invalid song cache format, rescanning");
             SongCacheIn.close();
             ScanSongs(songsFolder);
-            return LoadCache(songsFolder);
+            LoadCache(songsFolder);
+            return;
         }
 
-        uint16_t version;
-        SongCacheIn.read(reinterpret_cast<char*>(&version), 2);
-        if (version != CACHE_VERSION) {
-            TraceLog(LOG_WARNING, TextFormat("Cache version %01i, but current version is %01i",version, CACHE_VERSION));
+        uint32_t version;
+        SongCacheIn >> version;
+        if (version != SONG_CACHE_VERSION) {
+            TraceLog(LOG_WARNING, TextFormat("Cache version %01i, but current version is %01i",version, SONG_CACHE_VERSION));
             SongCacheIn.close();
             ScanSongs(songsFolder);
-            return LoadCache(songsFolder);
+            LoadCache(songsFolder);
+            return;
         }
 
-        size_t size;
-        SongCacheIn.read(reinterpret_cast<char*>(&size), sizeof(size));
-        list.songs.resize(size);
+        size_t cachedSongCount;
+        SongCacheIn >> cachedSongCount;
+
         TraceLog(LOG_INFO, "Loading song cache");
-
         std::set<std::string> loadedSongs;  // To track loaded songs and avoid duplicates
-        int idx = 0;
-        for (auto& ___ : list.songs) {
-            size_t nameLen = 0, albumArtPathLen = 0, directoryLen = 0, jsonPathLen = 0, artistLen = 0, lengthLen = 0;
-            std::string LengthString;
-            Song& song = list.songs[idx];
-            SongCacheIn.read(reinterpret_cast<char*>(&nameLen), 8);
-            song.title.resize(nameLen);
-            SongCacheIn.read(&song.title[0], nameLen);
+        for (int i = 0; i < cachedSongCount; i++) {
+            Song song;
 
-            SongCacheIn.read(reinterpret_cast<char*>(&directoryLen), 8);
-            song.songDir.resize(directoryLen);
-            SongCacheIn.read(&song.songDir[0], directoryLen);
-            
+            // Read cache values
+            song.songDir = ReadString(SongCacheIn);
+            song.albumArtPath = ReadString(SongCacheIn);
+            song.songInfoPath = ReadString(SongCacheIn);
+            song.jsonHash = ReadString(SongCacheIn);
+
+            song.title = ReadString(SongCacheIn);
+            song.artist = ReadString(SongCacheIn);
+
+            SongCacheIn >> song.length;
 
             TraceLog(LOG_INFO, TextFormat("Directory - %s", song.songDir.c_str()));
 
-            SongCacheIn.read(reinterpret_cast<char*>(&albumArtPathLen), 8);
-            song.albumArtPath.resize(albumArtPathLen);
-            SongCacheIn.read(&song.albumArtPath[0], albumArtPathLen);
+            if (!std::filesystem::exists(song.songDir)) {
+                continue;
+            }
 
-            SongCacheIn.read(reinterpret_cast<char*>(&artistLen), 8);
-            song.artist.resize(artistLen);
-            SongCacheIn.read(&song.artist[0], artistLen);
-
-            SongCacheIn.read(reinterpret_cast<char*>(&jsonPathLen), 8);
-            song.songInfoPath.resize(jsonPathLen);
-            SongCacheIn.read(&song.songInfoPath[0], jsonPathLen);
-            if (song.songInfoPath == ((std::filesystem::path)song.songDir / "song.ini"))
+            // Set other info properties
+            if (std::filesystem::path(song.songInfoPath).filename() == "song.ini") {
                 song.ini = true;
-            song.jsonHash.resize(64);
-            SongCacheIn.read(&song.jsonHash[0], 64);
+            }
 
             std::ifstream jsonFile(song.songInfoPath);
             std::string jsonHashNew = "";
             if (jsonFile) {
-                std::string jsonString((std::istreambuf_iterator<char>(jsonFile)), std::istreambuf_iterator<char>());
+                auto itBegin = std::istreambuf_iterator<char>(jsonFile);
+                auto itEnd = std::istreambuf_iterator<char>();
+                std::string jsonString(itBegin, itEnd);
                 jsonFile.close();
+
                 jsonHashNew = picosha2::hash256_hex_string(jsonString);
             }
-            
-            
-            SongCacheIn.read(reinterpret_cast<char*>(&lengthLen), 8);
-            LengthString.resize(lengthLen);
-            SongCacheIn.read(&LengthString[0], lengthLen);
 
-            song.length = std::stoi(LengthString);
-            if (!std::filesystem::exists(song.songDir))
+            if (song.jsonHash != jsonHashNew) {
                 continue;
-            if (song.jsonHash != jsonHashNew)
-                continue;
+            }
+
+            songs.push_back(std::move(song));
             loadedSongs.insert(song.songDir);
-            idx++;
         }
-        list.songs.resize(idx);
+
         SongCacheIn.close();
-        int loadedFromCache = list.songs.size();
+        size_t loadedSongCount = songs.size();
+
         // Load additional songs from directories if needed
         for (const auto& folder : songsFolder) {
-            for (const auto& entry : std::filesystem::directory_iterator(folder)) {
-                if (std::filesystem::is_directory(entry)) {
-                    if (std::filesystem::exists(entry.path() / "info.json")) {
-                        if (loadedSongs.find(entry.path().string()) == loadedSongs.end()) {
-                            Song song;
-                            song.LoadSong(entry.path() / "info.json");
-                            list.songs.push_back(song);
-                            list.songCount++;
-                        }
-                        else {
-                            list.badSongCount++;
-                        }
-                    }
-                    if (std::filesystem::exists(entry.path() / "song.ini")) {
-                        if (loadedSongs.find(entry.path().string()) == loadedSongs.end()) {
-                            Song song;
+            if (!std::filesystem::is_directory(folder)) {
+                continue;
+            }
 
-                            song.songInfoPath = (entry.path() / "song.ini").string();
-                            song.songDir = entry.path().string();
-                            song.LoadSongIni(entry.path());
-                            song.ini = true;
-                            list.songs.push_back(song);
-                            list.songCount++;
-                        } else {
-                            list.badSongCount++;
-                        }
+            for (const auto& entry : std::filesystem::directory_iterator(folder)) {
+                if (!std::filesystem::is_directory(entry)) {
+                    continue;
+                }
+
+                if (std::filesystem::exists(entry.path() / "info.json")) {
+                    if (loadedSongs.find(entry.path().string()) == loadedSongs.end()) {
+                        Song song;
+                        song.LoadSong(entry.path() / "info.json");
+                        songs.push_back(std::move(song));
+                        songCount++;
+                    }
+                    else {
+                        badSongCount++;
+                    }
+                }
+
+                if (std::filesystem::exists(entry.path() / "song.ini")) {
+                    if (loadedSongs.find(entry.path().string()) == loadedSongs.end()) {
+                        Song song;
+                        song.songInfoPath = (entry.path() / "song.ini").string();
+                        song.songDir = entry.path().string();
+                        song.LoadSongIni(entry.path());
+                        song.ini = true;
+
+                        songs.push_back(std::move(song));
+                        songCount++;
+                    } else {
+                        badSongCount++;
                     }
                 }
             }
         }
 
-        if (size!=loadedFromCache || list.songs.size() > loadedFromCache) {
+        if (cachedSongCount != loadedSongCount || songs.size() != loadedSongCount) {
             TraceLog(LOG_INFO, "Updating song cache");
-            WriteCache(list.songs);
+            WriteCache();
         }
+
         // ScanSongs(songsFolder);
-        list.sortList(0);
-        return list;
+        sortList(SortType::Title);
     }
 };
 

--- a/Encore/src/util/binary.h
+++ b/Encore/src/util/binary.h
@@ -1,0 +1,465 @@
+#pragma once
+
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace encore {
+
+    /*
+     * Custom byteswap implementation
+     *
+     * This implementation supports byteswapping floating-point values,
+     * in addition to integral values, which simplifies binary stream implementations.
+     */
+
+#define HAS_BYTESWAP (__cpp_lib_byteswap >= 202110L)
+
+#if !HAS_BYTESWAP
+    namespace impl {
+        constexpr inline uint16_t byteswap_16(uint16_t value) noexcept {
+            value = (value & 0xFF00) >> 8 | (value & 0x00FF) << 8;
+            return value;
+        }
+
+        constexpr inline uint32_t byteswap_32(uint32_t value) noexcept {
+            value = ((value & 0xFFFF0000) >> 16) | ((value & 0x0000FFFF) << 16);
+            value = ((value & 0xFF00FF00) >> 8)  | ((value & 0x00FF00FF) << 8);
+            return value;
+        }
+
+        constexpr inline uint64_t byteswap_64(uint64_t value) noexcept {
+            value = ((value & 0xFFFFFFFF00000000) >> 32) | ((value & 0x00000000FFFFFFFF) << 32);
+            value = ((value & 0xFFFF0000FFFF0000) >> 16) | ((value & 0x0000FFFF0000FFFF) << 16);
+            value = ((value & 0xFF00FF00FF00FF00) >> 8)  | ((value & 0x00FF00FF00FF00FF) << 8);
+            return value;
+        }
+    }
+#endif
+
+    /// Custom byteswap which allows floating-point values.
+    template <typename T>
+    [[nodiscard]]
+    constexpr inline T byteswap(const T value) noexcept
+        requires std::integral<T> || std::floating_point<T>
+    {
+#if HAS_BYTESWAP // Take advantage of std::byteswap if available, for intrinsics
+        if constexpr (std::integral<T>) {
+            return std::byteswap(value);
+        } else if constexpr (sizeof(T) == 4) {
+            return std::bit_cast<T>(std::byteswap(std::bit_cast<uint32_t>(value)));
+        } else {
+            static_assert(sizeof(T) == 8, "Unexpected float size");
+            return std::bit_cast<T>(std::byteswap(std::bit_cast<uint64_t>(value)));
+        }
+#else
+        if constexpr (sizeof(T) == 1) {
+            return value;
+        } else if constexpr (sizeof(T) == 2) {
+            return std::bit_cast<T>(impl::byteswap_16(std::bit_cast<uint16_t>(value)));
+        } else if constexpr (sizeof(T) == 4) {
+            return std::bit_cast<T>(impl::byteswap_32(std::bit_cast<uint32_t>(value)));
+        } else {
+            static_assert(sizeof(T) == 8, "Unexpected value size");
+            return std::bit_cast<T>(impl::byteswap_64(std::bit_cast<uint64_t>(value)));
+        }
+#endif
+    }
+
+#undef HAS_BYTESWAP
+
+    /*
+     * Endianness conversion
+     *
+     * note(Nate): convert_endian, to_endian, and from_endian all techically function identically,
+     * but i was having a hard time wrapping my head around that, so i made them distinct for clarity
+     */
+
+    // We don't support anything other than little- or big-endian
+    static_assert(
+        std::endian::native == std::endian::little ||
+        std::endian::native == std::endian::big
+    );
+
+    /// Converts a value with the given source endianness to a value with the target endianness.
+    template <std::endian SourceEndian, std::endian TargetEndian>
+    [[nodiscard]]
+    constexpr inline auto convert_endian(auto value) noexcept {
+        if constexpr (SourceEndian == TargetEndian) {
+            return value;
+        } else {
+            return byteswap(value);
+        }
+    }
+
+    /// Converts a value of native endianness to a value with the target endianness.
+    template <std::endian TargetEndian>
+    [[nodiscard]]
+    constexpr inline auto to_endian(auto value) noexcept {
+        return convert_endian<std::endian::native, TargetEndian>(value);
+    }
+
+    /// Converts a value with the given source endianness to a value of native endianness.
+    template <std::endian SourceEndian>
+    [[nodiscard]]
+    constexpr inline auto from_endian(auto value) noexcept {
+        return convert_endian<SourceEndian, std::endian::native>(value);
+    }
+
+    /*
+     * Binary stream wrappers
+     *
+     * Because istream/ostream were designed for text and not binary data.
+     * Thanks, C++.
+     */
+
+    template <typename T>
+    concept closable_stream = std::derived_from<T, std::ios> && requires(T stream) {
+        { stream.close() } -> std::same_as<void>;
+    };
+
+    template <std::derived_from<std::ios> Stream>
+    class binstream_base {
+    protected:
+        std::unique_ptr<Stream> mStream;
+
+    public:
+        using iostate = typename Stream::iostate;
+
+        template <class... Ts>
+        binstream_base(Ts&&... _Val)
+            : mStream(std::make_unique<Stream, Ts...>(std::forward<Ts>(_Val)...)) { }
+
+        binstream_base(std::unique_ptr<Stream>&& stream)
+            : mStream(std::move(stream)) { }
+
+        binstream_base(const binstream_base&) = delete;
+        binstream_base(binstream_base&&) = default;
+
+        binstream_base& operator=(const binstream_base&) = delete;
+        binstream_base& operator=(binstream_base&&) = default;
+
+        [[nodiscard]]
+        bool good() const noexcept(noexcept(mStream->good())) {
+            return mStream->good();
+        }
+
+        [[nodiscard]]
+        bool eof() const noexcept(noexcept(mStream->eof())) {
+            return mStream->eof();
+        }
+
+        [[nodiscard]]
+        bool fail() const noexcept(noexcept(mStream->fail())) {
+            return mStream->fail();
+        }
+
+        [[nodiscard]]
+        bool bad() const noexcept(noexcept(mStream->bad())) {
+            return mStream->bad();
+        }
+
+        explicit operator bool() const noexcept(noexcept(mStream->operator bool())) {
+            return mStream->operator bool();
+        }
+
+        [[nodiscard]]
+        bool operator!() const noexcept(noexcept(mStream->operator!())) {
+            return mStream->operator!();
+        }
+
+        [[nodiscard]]
+        iostate rdstate() const {
+            return mStream->rdstate();
+        }
+
+        void setstate(iostate state) {
+            mStream->setstate(state);
+        }
+
+        void clear(iostate state = Stream::goodbit) {
+            mStream->clear(state);
+        }
+
+        void close() noexcept(noexcept(mStream->close()))
+            requires closable_stream<Stream>
+        {
+            mStream->close();
+        }
+    };
+
+    /// Reads binary values from a stream using the specified endianness.
+    template <std::derived_from<std::istream> Stream, std::endian SourceEndian>
+    class bin_istream : public binstream_base<Stream> {
+    public:
+        static constexpr std::endian endianness = SourceEndian;
+
+        template <class... Ts>
+        bin_istream(Ts&&... _Val)
+            : binstream_base<Stream>(std::forward<Ts>(_Val)...) { }
+
+        bin_istream(std::unique_ptr<Stream>&& stream)
+            : binstream_base<Stream>(std::move(stream)) { }
+
+        /// Allows reading raw data from the underlying stream, without endianness considerations.
+        [[maybe_unused]]
+        bin_istream& read_raw(void* data, std::streamsize size) {
+            binstream_base<Stream>::mStream->read(reinterpret_cast<char*>(data), size);
+            return *this;
+        }
+
+#define BINSTREAM_READ_OP(valueType) \
+        [[maybe_unused]] \
+        bin_istream& operator>>(valueType& value) { \
+            read_raw(&value, sizeof(value)); \
+            value = from_endian<endianness>(value); \
+            return *this; \
+        }
+
+        BINSTREAM_READ_OP(char)
+        BINSTREAM_READ_OP(wchar_t)
+        BINSTREAM_READ_OP(char8_t)
+        BINSTREAM_READ_OP(char16_t)
+        BINSTREAM_READ_OP(char32_t)
+
+        BINSTREAM_READ_OP(unsigned char)
+        BINSTREAM_READ_OP(unsigned short)
+        BINSTREAM_READ_OP(unsigned int)
+        BINSTREAM_READ_OP(unsigned long)
+        BINSTREAM_READ_OP(unsigned long long)
+
+        BINSTREAM_READ_OP(signed char)
+        BINSTREAM_READ_OP(signed short)
+        BINSTREAM_READ_OP(signed int)
+        BINSTREAM_READ_OP(signed long)
+        BINSTREAM_READ_OP(signed long long)
+
+        BINSTREAM_READ_OP(float)
+        BINSTREAM_READ_OP(double)
+        BINSTREAM_READ_OP(long double)
+
+        [[maybe_unused]]
+        bin_istream& operator>>(bool& value) {
+            uint8_t read = 0;
+            (*this) >> read;
+            value = read != 0;
+            return *this;
+        }
+
+#undef BINSTREAM_READ_OP
+    };
+
+    /// Reads binary values from a stream, in little-endian byte order.
+    template <std::derived_from<std::istream> Stream>
+    using bin_istream_le = bin_istream<Stream, std::endian::little>;
+
+    /// Reads binary values from a stream, in big-endian byte order.
+    template <std::derived_from<std::istream> Stream>
+    using bin_istream_be = bin_istream<Stream, std::endian::big>;
+
+    /// Reads binary values from a stream, in native-endian byte order.
+    template <std::derived_from<std::istream> Stream>
+    using bin_istream_native = bin_istream<Stream, std::endian::native>;
+
+    /// Reads binary values from a file stream, in little-endian byte order.
+    using bin_ifstream_le = bin_istream_le<std::ifstream>;
+
+    /// Reads binary values from a file stream, in big-endian byte order.
+    using bin_ifstream_be = bin_istream_be<std::ifstream>;
+
+    /// Reads binary values from a file stream, in native-endian byte order.
+    using bin_ifstream_native = bin_istream_native<std::ifstream>;
+
+    /// Writes binary values to a stream using the specified endianness.
+    template <std::derived_from<std::ostream> Stream, std::endian TargetEndian>
+    class bin_ostream : public binstream_base<Stream> {
+    public:
+        static constexpr std::endian endianness = TargetEndian;
+
+        template <class... Ts>
+        bin_ostream(Ts&&... _Val)
+            : binstream_base<Stream>(std::forward<Ts>(_Val)...) { }
+
+        bin_ostream(std::unique_ptr<Stream>&& stream)
+            : binstream_base<Stream>(std::move(stream)) { }
+
+        /// Allows writing raw data to the underlying stream, without endianness considerations.
+        [[maybe_unused]]
+        bin_ostream& write_raw(const void* data, std::streamsize size) {
+            binstream_base<Stream>::mStream->write(reinterpret_cast<const char*>(data), size);
+            return *this;
+        }
+
+#define BINSTREAM_WRITE_OP(valueType) \
+        [[maybe_unused]] \
+        bin_ostream& operator<<(const valueType value) { \
+            const valueType converted = to_endian<endianness>(value); \
+            write_raw(&converted, sizeof(converted)); \
+            return *this; \
+        }
+
+        BINSTREAM_WRITE_OP(char)
+        BINSTREAM_WRITE_OP(wchar_t)
+        BINSTREAM_WRITE_OP(char8_t)
+        BINSTREAM_WRITE_OP(char16_t)
+        BINSTREAM_WRITE_OP(char32_t)
+
+        BINSTREAM_WRITE_OP(unsigned char)
+        BINSTREAM_WRITE_OP(unsigned short)
+        BINSTREAM_WRITE_OP(unsigned int)
+        BINSTREAM_WRITE_OP(unsigned long)
+        BINSTREAM_WRITE_OP(unsigned long long)
+
+        BINSTREAM_WRITE_OP(signed char)
+        BINSTREAM_WRITE_OP(signed short)
+        BINSTREAM_WRITE_OP(signed int)
+        BINSTREAM_WRITE_OP(signed long)
+        BINSTREAM_WRITE_OP(signed long long)
+
+        BINSTREAM_WRITE_OP(float)
+        BINSTREAM_WRITE_OP(double)
+        BINSTREAM_WRITE_OP(long double)
+
+        [[maybe_unused]]
+        bin_ostream& operator<<(const bool value) {
+            operator<<(static_cast<unsigned char>(value));
+            return *this;
+        }
+
+#undef BINSTREAM_WRITE_OP
+    };
+
+    /// Writes binary values to a stream, in little-endian byte order.
+    template <std::derived_from<std::ostream> Stream>
+    using bin_ostream_le = bin_ostream<Stream, std::endian::little>;
+
+    /// Writes binary values to a stream, in big-endian byte order.
+    template <std::derived_from<std::ostream> Stream>
+    using bin_ostream_be = bin_ostream<Stream, std::endian::big>;
+
+    /// Writes binary values to a stream, in native-endian byte order.
+    template <std::derived_from<std::ostream> Stream>
+    using bin_ostream_native = bin_ostream<Stream, std::endian::native>;
+
+    /// Writes binary values to a file stream, in little-endian byte order.
+    using bin_ofstream_le = bin_ostream_le<std::ofstream>;
+
+    /// Writes binary values to a file stream, in big-endian byte order.
+    using bin_ofstream_be = bin_ostream_be<std::ofstream>;
+
+    /// Writes binary values to a file stream, in native-endian byte order.
+    using bin_ofstream_native = bin_ostream_native<std::ofstream>;
+
+    /*
+     * Binary stream concepts and freestanding operators
+     *
+     * Operators for reading/writing std types go here.
+     */
+
+    /// Specifies that a type is readable from a bin_istream using the >> operator.
+    template <typename T, typename Stream, std::endian Endian>
+    concept binary_readable = requires(T t, bin_istream<Stream, Endian> stream) {
+        stream >> t;
+    };
+
+    /// Specifies that a type is writable to a bin_ostream using the << operator.
+    template <typename T, typename Stream, std::endian Endian>
+    concept binary_writable = requires(T t, bin_ostream<Stream, Endian> stream) {
+        stream << t;
+    };
+
+    /// Reads a vector of elements from the stream.
+    template <std::derived_from<std::istream> Stream, std::endian Endian,
+		binary_readable<Stream, Endian> T>
+    [[maybe_unused]]
+    bin_istream<Stream, Endian>& operator>>(
+		bin_istream<Stream, Endian>& stream,
+		std::vector<T>& value
+	) {
+        size_t length = 0;
+        stream >> length;
+
+        value.resize(length);
+        for (auto& item : value) {
+            stream >> item;
+        }
+
+        return stream;
+    }
+
+    /// Writes a vector of elements to the stream.
+    template <std::derived_from<std::ostream> Stream, std::endian Endian,
+		binary_writable<Stream, Endian> T>
+    [[maybe_unused]]
+    bin_ostream<Stream, Endian>& operator<<(
+		bin_ostream<Stream, Endian>& stream,
+		const std::vector<T>& value
+	) {
+        stream << (size_t)value.size();
+
+        for (auto& item : value) {
+            stream << item;
+        }
+
+        return stream;
+    }
+
+    /// Reads a string from the stream.
+    template <std::derived_from<std::istream> Stream, std::endian Endian,
+		typename Char, typename Traits, typename Alloc>
+    [[maybe_unused]]
+    bin_istream<Stream, Endian>& operator>>(
+        bin_istream<Stream, Endian>& stream,
+        std::basic_string<Char, Traits, Alloc>& value
+    )
+        requires binary_readable<Char, Stream, Endian>
+    {
+        size_t length = 0;
+        stream >> length;
+
+        value.resize(length, '\0');
+        if constexpr (std::endian::native == Endian || sizeof(Char) == 1) {
+            // Read raw data directly
+            stream.read_raw(value.data(), value.length() * sizeof(Char));
+        } else {
+            // Read one character at a time for correct endianness
+            for (auto& character : value) {
+                stream >> character;
+            }
+        }
+
+        return stream;
+    }
+
+    /// Writes a string to the stream.
+    template <std::derived_from<std::ostream> Stream, std::endian Endian,
+		typename Char, typename Traits, typename Alloc>
+    [[maybe_unused]]
+    bin_ostream<Stream, Endian>& operator<<(
+        bin_ostream<Stream, Endian>& stream,
+        const std::basic_string<Char, Traits, Alloc>& value
+    )
+        requires binary_writable<Char, Stream, Endian>
+    {
+        stream << (size_t)value.size();
+
+        if constexpr (std::endian::native == Endian || sizeof(Char) == 1) {
+            // Write raw data directly
+            stream.write_raw(value.data(), value.length() * sizeof(Char));
+        } else {
+            // Write one character at a time for correct endianness
+            for (auto& character : value) {
+                stream << character;
+            }
+        }
+
+        return stream;
+    }
+
+}


### PR DESCRIPTION
brain is fry :finnadie:

Added new `bin_istream`/`bin_ostream` types, which are wrappers around `istream`/`ostream` that write binary data instead of formatted text.

Cleaned up cache reading/writing to use `<<`/`>>` operators instead of manual `read`/`write` calls, and to avoid a potential recursive loop when bugged code causes the written cache to always be malformed.

Cache header/version has been refactored: version is now 4 bytes and based on the date the format was last modified, and header has been reduced to 4 bytes to fit the 4-byte date version.

Added a `SortType` enum for available sort types, replacing the hard-coded magic numbers used previously. Also comes with a `NextSortType` helper function, because C++ enums aren't incrementable by default, and doing wraparound in an `operator++` felt weird.

General code tidy; sorted includes in songlist.h, reduced nesting, moved fields to before the first method, turned some static methods into instance methods where they made better sense, etc.

probably some other small things i forgot