### PR TITLE
Fix macOS Actions builds

### DIFF
--- a/Encore/src/song/songlist.h
+++ b/Encore/src/song/songlist.h
@@ -17,6 +17,12 @@ struct ListMenuEntry {
     int songListID;
     std::string headerChar;
     bool hiddenEntry;
+    ListMenuEntry(bool _isHeader, int _songListID, std::string _headerChar, bool _hiddenEntry) {
+        isHeader = _isHeader;
+        songListID = _songListID;
+        headerChar = _headerChar;
+        hiddenEntry = _hiddenEntry;
+    }
 };
 
 enum class SortType : int {

--- a/create-macos-app.sh
+++ b/create-macos-app.sh
@@ -22,7 +22,14 @@ install_name_tool -add_rpath @executable_path out/Encore.app/Contents/MacOS/Enco
 # Delete the gitkeep file if it exists
 rm out/Encore.app/Contents/MacOS/.gitkeep
 
+# Apply an ad-hoc code signature
+codesign --force --deep -s - out/Encore.app
+
 # Copy out the Songs folder
 cp -r build_macos/Encore/Songs out/Songs
+
+# -- !! TEMPORARY INDEV HACK !! --
+cp build_macos/Encore/players.json out/players.json
+# -- !! TEMPORARY INDEV HACK !! --
 
 echo "Copy the Encore app and the Songs folder to a folder on your computer." > out/Copy_to_your_computer!.txt


### PR DESCRIPTION
this also copies the required players.json into the output directory *for now*, in the create-macos-app.sh script directly