### PR TITLE
chore: warning cleanup

### DIFF
--- a/Encore/src/RhythmEngine/ChartLoaders/BaseLoader.h
+++ b/Encore/src/RhythmEngine/ChartLoaders/BaseLoader.h
@@ -61,12 +61,12 @@ namespace Encore::RhythmEngine {
         // run these few things:
         // midiFile.absoluteTicks();
         // midiFile.doTimeAnalysis();
-        BaseLoader(int diff_, int thresh_, smf::MidiFile* midiFile_) : Difficulty(diff_), Threshold(thresh_), midiFile(midiFile_) {}
+        BaseLoader(int diff_, int thresh_, smf::MidiFile* midiFile_) : midiFile(midiFile_), Difficulty(diff_), Threshold(thresh_){}
 
-        int CurrentSolo = 0;
-        int CurrentOverdrive = 0;
-        int CurrentTrill = 0;
-        int CurrentRoll = 0;
+        size_t CurrentSolo = 0;
+        size_t CurrentOverdrive = 0;
+        size_t CurrentTrill = 0;
+        size_t CurrentRoll = 0;
 
         smf::MidiFile* midiFile;
         BaseChart chart;

--- a/Encore/src/RhythmEngine/ChartLoaders/DrumsLoader.cpp
+++ b/Encore/src/RhythmEngine/ChartLoaders/DrumsLoader.cpp
@@ -4,6 +4,7 @@
 
 #include "DrumsLoader.h"
 
+#include "RhythmEngine/REenums.h"
 #include <regex>
 
 #include "song/scoring.h"

--- a/Encore/src/RhythmEngine/ChartLoaders/DrumsLoader.h
+++ b/Encore/src/RhythmEngine/ChartLoaders/DrumsLoader.h
@@ -6,6 +6,7 @@
 #define DRUMSLOADER_H
 
 #include "BaseLoader.h"
+#include <queue>
 
 namespace Encore::RhythmEngine {
     class DrumsLoader final : public BaseLoader {

--- a/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.cpp
+++ b/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.cpp
@@ -136,7 +136,7 @@ void Encore::RhythmEngine::GuitarLoader::CreateNote(const smf::MidiEvent &event)
         lengthSec = 0;
     }
     if (lengthTicks > 0) {
-        chart.BaseScore += (lengthTicks / 480) * BASE_SCORE_SUSTAIN_POINTS;
+        chart.BaseScore += static_cast<double>(int(lengthTicks / 480)) * BASE_SCORE_SUSTAIN_POINTS;
         lengthTicks -= 1;
     }
     if (!OpenMarker.empty()) {

--- a/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.cpp
+++ b/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.cpp
@@ -4,6 +4,7 @@
 
 #include "GuitarLoader.h"
 
+#include "RhythmEngine/REenums.h"
 #include "song/scoring.h"
 std::vector<smf::uchar> psDiff { 0x00, 0x01, 0x02, 0x03 };
 

--- a/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.h
+++ b/Encore/src/RhythmEngine/ChartLoaders/GuitarLoader.h
@@ -6,6 +6,7 @@
 #define GUITARLOADER_H
 
 #include "BaseLoader.h"
+#include <queue>
 
 namespace Encore::RhythmEngine {
     class GuitarLoader final : public BaseLoader {

--- a/Encore/src/RhythmEngine/ChartLoaders/LyricLoader.cpp
+++ b/Encore/src/RhythmEngine/ChartLoaders/LyricLoader.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "LyricLoader.h"
+#include "raylib.h"
+#include "util/enclog.h"
 
 void Encore::RhythmEngine::LyricLoader::LoadLyrics() {
     if (midiFile) {
@@ -86,7 +88,7 @@ void Encore::RhythmEngine::LyricLoader::GetNotes(smf::MidiEventList *midiEventLi
             talkie = true;
             break;
         }
-        for (int i = 0; i < lyric.size() - 1; i++) {
+        for (size_t i = 0; i < lyric.size() - 1; i++) {
             static const char *sectionSym = "§";
             if (lyric[i] == sectionSym[0] && lyric[i + 1] == sectionSym[1]) {
                 lyric.erase(lyric.begin() + i);

--- a/Encore/src/RhythmEngine/ChartLoaders/LyricLoader.h
+++ b/Encore/src/RhythmEngine/ChartLoaders/LyricLoader.h
@@ -4,11 +4,14 @@
 
 #ifndef ENCORE_LYRICLOADER_H
 #define ENCORE_LYRICLOADER_H
-#include "BaseLoader.h"
+
+#include "RhythmEngine/Notes/EncNote.h"
+#include "midifile/MidiFile.h"
+#include <cstdint>
 
 namespace Encore::RhythmEngine {
     class LyricLoader {
-        int CurrentPhrase = 0;
+        uint32_t CurrentPhrase = 0;
         smf::MidiFile *midiFile;
         int trackIdx;
 

--- a/Encore/src/RhythmEngine/ChartLoaders/PadLoader.cpp
+++ b/Encore/src/RhythmEngine/ChartLoaders/PadLoader.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "PadLoader.h"
+#include "RhythmEngine/REenums.h"
 
 #include "song/scoring.h"
 
@@ -40,7 +41,9 @@ void Encore::RhythmEngine::PadLoader::CheckEvents(const smf::MidiEvent &event) {
     ITERATE_EVENT_BY_NOTE(solos, CurrentSolo, event)
     if (!chart.overdrive.empty()) {
         if (CurrentOverdrive < chart.overdrive.size() - 1
-            && chart.overdrive[CurrentOverdrive].StartTick + chart.overdrive[CurrentOverdrive].EndTick <= event.tick)
+            && chart.overdrive[CurrentOverdrive].StartTick
+                    + chart.overdrive[CurrentOverdrive].EndTick
+                <= event.tick)
             CurrentOverdrive++;
     }
     // ITERATE_EVENT_BY_NOTE(overdrive, CurrentOverdrive, event)
@@ -81,7 +84,12 @@ void Encore::RhythmEngine::PadLoader::CreateNote(const smf::MidiEvent &event) {
     }
     chart[GetEventLane(Difficulty, event)].emplace_back(
 
-        event.tick, lengthTicks, event.seconds, lengthSec, GetNoteType(event), PlasticFrets[GetEventLane(Difficulty, event)]
+        event.tick,
+        lengthTicks,
+        event.seconds,
+        lengthSec,
+        GetNoteType(event),
+        PlasticFrets[GetEventLane(Difficulty, event)]
 
     );
     // i hate how solos need note counts before entering lol

--- a/Encore/src/RhythmEngine/ChartLoaders/PadLoader.h
+++ b/Encore/src/RhythmEngine/ChartLoaders/PadLoader.h
@@ -6,6 +6,8 @@
 #define PADLOADER_H
 
 #include "BaseLoader.h"
+#include <array>
+#include <queue>
 
 namespace Encore::RhythmEngine {
     class PadLoader final : public BaseLoader {

--- a/Encore/src/RhythmEngine/Engine/BaseStats.h
+++ b/Encore/src/RhythmEngine/Engine/BaseStats.h
@@ -5,7 +5,6 @@
 #ifndef BASESTATS_H
 #define BASESTATS_H
 #include <array>
-#include <vector>
 #include "Overdrive.h"
 #include "assets.h"
 #include "settings/settings.h"

--- a/Encore/src/RhythmEngine/Engine/DrumsEngine.cpp
+++ b/Encore/src/RhythmEngine/Engine/DrumsEngine.cpp
@@ -104,7 +104,7 @@ void Encore::RhythmEngine::DrumsEngine::HitNote(int lane) {
 }
 
 void Encore::RhythmEngine::DrumsEngine::UpdateOnFrame(double CurrentTime) {
-    for (int Lane = 0; Lane < chart->Lanes.size(); Lane++) {
+    for (size_t Lane = 0; Lane < chart->Lanes.size(); Lane++) {
         if (stats->Bot) {
             if (chart->CurrentNoteIterators.at(Lane) < chart->Lanes.at(Lane).cend()) {
                 EncNote *CurrentNote = &*chart->CurrentNoteIterators.at(Lane);

--- a/Encore/src/RhythmEngine/Engine/GuitarEngine.cpp
+++ b/Encore/src/RhythmEngine/Engine/GuitarEngine.cpp
@@ -9,7 +9,6 @@
 #include "song/scoring.h"
 
 #include <bit>
-#include <filesystem>
 
 #include "song/audio.h"
 
@@ -47,8 +46,7 @@ bool HittableAsStrum(int NoteType, bool FAS, double inputTime, double FASTime) {
 bool Encore::RhythmEngine::GuitarEngine::ActivateOverdrive(ControllerEvent &event
 ) {
     if (event.channel == InputChannel::OVERDRIVE && event.action == Action::PRESS) {
-        int InstrumentNum =
-            stats->Type == Guitar ? inst - 5 : inst;
+        // int InstrumentNum = stats->Type == Guitar ? inst - 5 : inst;
         if (stats->overdrive.Activate(stats->InputTime)) {
             HighwayBounceEvent HBevent;
             FireEvent(&HBevent);
@@ -106,8 +104,7 @@ void Encore::RhythmEngine::GuitarEngine::UpdateOnFrame(double CurrentTime) {
     bool odWasActive = stats->overdrive.Active;
     stats->overdrive.Update(CurrentTime);
     if (odWasActive == true && odWasActive != stats->overdrive.Active) {
-        int InstrumentNum =
-            stats->Type == Guitar ? inst - 5 : inst;
+        // int InstrumentNum = stats->Type == Guitar ? inst - 5 : inst;
         TheAudioManager.StopEffect(TheAudioManager.GetAudioStreamByInstrument(inst));
         EncoreLog(LOG_DEBUG, TextFormat("Instrument: %i", inst));
     }

--- a/Encore/src/RhythmEngine/Engine/GuitarEngine.h
+++ b/Encore/src/RhythmEngine/Engine/GuitarEngine.h
@@ -54,7 +54,7 @@ namespace Encore::RhythmEngine {
             Timers = { { "FAS", RhythmTimer(0.125) }, { "SAH", RhythmTimer(goodBackend + goodFrontend) } };
         };
         ~GuitarEngine() override {};
-        virtual bool UsesNoteMasks() {return true;};
+        virtual bool UsesNoteMasks() override {return true;};
     };
 }
 

--- a/Encore/src/RhythmEngine/Engine/Overdrive.cpp
+++ b/Encore/src/RhythmEngine/Engine/Overdrive.cpp
@@ -2,9 +2,12 @@
 // Created by maria on 26/08/2025.
 //
 
+#include "Overdrive.h"
+#include "assets.h"
 #include "gameplay/enctime.h"
+#include "settings/settings.h"
+#include "song/audio.h"
 #include "util/enclog.h"
-#include "BaseStats.h"
 #include "RhythmEngine/NoteVector.h"
 
 void Encore::RhythmEngine::Overdrive::Update(double &CurrentTime) {

--- a/Encore/src/RhythmEngine/Engine/Overdrive.h
+++ b/Encore/src/RhythmEngine/Engine/Overdrive.h
@@ -5,6 +5,9 @@
 #ifndef ENCORE_OVERDRIVE_H
 #define ENCORE_OVERDRIVE_H
 #include "RhythmEngine/NoteVector.h"
+
+#include <memory>
+
 namespace Encore::RhythmEngine {
     class Overdrive {
     public:

--- a/Encore/src/RhythmEngine/Engine/PadEngine.cpp
+++ b/Encore/src/RhythmEngine/Engine/PadEngine.cpp
@@ -19,7 +19,7 @@ bool Encore::RhythmEngine::PadEngine::ActivateOverdrive(ControllerEvent &event) 
         if (stats->overdrive.Activate(stats->InputTime)) {
             HighwayBounceEvent HBevent(2.0f, 2.5f);
             FireEvent(&HBevent);
-            for (int lane = 0; lane < chart->Lanes.size(); lane++) {
+            for (size_t lane = 0; lane < chart->Lanes.size(); lane++) {
                 if (chart->CurrentNoteIterators.at(lane) != chart->Lanes.at(lane).end()){
                     EncNote *CurrentNote = &*chart->CurrentNoteIterators.at(lane);
                     if (InHitwindow(CurrentNote->StartSeconds)) {
@@ -32,7 +32,7 @@ bool Encore::RhythmEngine::PadEngine::ActivateOverdrive(ControllerEvent &event) 
     }
     if (event.channel == InputChannel::OVERDRIVE && event.action == Action::RELEASE) {
         if (stats->overdrive.UseOverdriveLift) {
-            for (int lane = 0; lane < chart->Lanes.size(); lane++) {
+            for (size_t lane = 0; lane < chart->Lanes.size(); lane++) {
                 if (chart->CurrentNoteIterators.at(lane) != chart->Lanes.at(lane).end()) {
                     EncNote *CurrentNote = &*chart->CurrentNoteIterators.at(lane);
                     if (InHitwindow(CurrentNote->StartSeconds) && CurrentNote->NoteType ==
@@ -90,7 +90,7 @@ int Encore::RhythmEngine::PadEngine::RunHitStateCheck(ControllerEvent &event) {
     if (event.channel == InputChannel::STRUM_UP || event.channel ==
         InputChannel::STRUM_DOWN)
         return CheckNextInput;
-    int lane = ICInt(event.channel);
+    size_t lane = ICInt(event.channel);
     if (lane >= chart->Lanes.size())
         return CheckNextInput;
 
@@ -129,7 +129,7 @@ void Encore::RhythmEngine::PadEngine::HitNote(int lane) {
 
 void Encore::RhythmEngine::PadEngine::UpdateOnFrame(double CurrentTime) {
     LastUpdateTime = CurrentTime;
-    for (int Lane = 0; Lane < chart->Lanes.size(); Lane++) {
+    for (size_t Lane = 0; Lane < chart->Lanes.size(); Lane++) {
         if (stats->Bot) {
             if (chart->CurrentNoteIterators.at(Lane) == chart->Lanes.at(Lane).end())
                 continue;

--- a/Encore/src/RhythmEngine/NoteVector.h
+++ b/Encore/src/RhythmEngine/NoteVector.h
@@ -4,13 +4,11 @@
 
 #ifndef NOTEVECTOR_H
 #define NOTEVECTOR_H
-#include "REenums.h"
+
 #include "Notes/EncNote.h"
 #include "RhythmEngine/events/EncEventVects/EventVectors.h"
 
-#include <array>
-#include <memory>
-#include <queue>
+#include <deque>
 #include <vector>
 
 inline std::vector<std::vector<int> > pDiffNotes = { { 60, 61, 62, 63, 64 },
@@ -53,7 +51,7 @@ namespace Encore::RhythmEngine {
             CurrentNoteIterators.resize(5);
             HeldNotePointers.resize(5);
         };
-        unsigned char size;
+        uint8_t size;
         NoteVector &operator[](const int i) { return this->Lanes.at(i); }
         NoteVector &at(const int i) { return this->Lanes.at(i); }
         std::vector<NoteVector> Lanes;
@@ -100,10 +98,10 @@ namespace Encore::RhythmEngine {
          * reset notes
          */
         void Reset(int lane) {
-            for (int i = 0; i < CurrentNoteIterators.size(); i++) {
+            for (size_t i = 0; i < CurrentNoteIterators.size(); i++) {
                 CurrentNoteIterators.at(i) = Lanes.at(i).begin();
             }
-            for (int i = 0; i < HeldNotePointers.size(); i++) {
+            for (size_t i = 0; i < HeldNotePointers.size(); i++) {
                 HeldNotePointers.at(i) = nullptr;
             }
         }

--- a/Encore/src/RhythmEngine/REenums.h
+++ b/Encore/src/RhythmEngine/REenums.h
@@ -84,8 +84,9 @@ namespace Encore::RhythmEngine {
             return InputChannel::LANE_4;
         case 4:
             return InputChannel::LANE_5;
+        default:
+            return InputChannel::INVALID;
         }
-        return InputChannel::INVALID;
     }
     inline int ICInt(InputChannel channel) {
         switch (channel) {
@@ -99,9 +100,10 @@ namespace Encore::RhythmEngine {
             return 3;
         case InputChannel::LANE_5:
             return 4;
+        default:
+            return 0;
         }
 
-        return 0;
     }
     enum class Action : int8_t {
         INVALID = -1,

--- a/Encore/src/RhythmEngine/events/EncEventVects/EncEventVect.h
+++ b/Encore/src/RhythmEngine/events/EncEventVects/EncEventVect.h
@@ -4,12 +4,13 @@
 
 #ifndef ENCEVENTVEC_H
 #define ENCEVENTVEC_H
+
 #include <vector>
 
 template <typename t>
 struct EncEventVect : std::vector<t> {
     virtual ~EncEventVect() = default;
-    int CurrentEvent = 0;
+    size_t CurrentEvent = 0;
 
     t &operator=(int event) { return this->at(event); }
 

--- a/Encore/src/assets.h
+++ b/Encore/src/assets.h
@@ -1,14 +1,11 @@
 #pragma once
 #include "raylib.h"
-#include "menus/uiUnits.h"
 #include "tracy/Tracy.hpp"
 #include "util/enclog.h"
 
 #include <cassert>
-#include <atomic>
 #include <filesystem>
 #include <functional>
-#include <map>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -68,8 +65,8 @@ public:
     }
 
     Asset(Asset &&other) noexcept
-        : id(std::move(other.id)),
-          state(state),
+        : state(other.state),
+          id(std::move(other.id)),
           loadingThread() {
     }
 
@@ -683,7 +680,7 @@ public:
                                     "offset",
                                     "scale"
                                 },
-                                [this](Shader* shader) {
+                                [](Shader* shader) {
                                 });
 
     NEWLEGACYMODELASSET(indicatorRing, "gameplay/track/multiplier/indicator_ring.obj",
@@ -725,7 +722,7 @@ public:
                                     "offset",
                                     "scale"
                                 },
-                                [this](Shader* shader) {
+                                [](Shader* shader) {
                                 });
 
     NEWTEXASSET(multNumTex, "gameplay/track/multiplier/mult_number.png");
@@ -780,7 +777,7 @@ public:
 
     void StartLoad() {
         ZoneScoped
-        for (int i = 0; i < assets.size(); i++) {
+        for (size_t i = 0; i < assets.size(); i++) {
             auto asset = assets[i];
             if (asset->state == UNLOADED) {
                 asset->StartLoad();
@@ -791,7 +788,7 @@ public:
     bool PollLoaded(bool doFinalize = false) {
         ZoneScoped
         bool loaded = true;
-        for (int i = 0; i < assets.size(); i++) {
+        for (size_t i = 0; i < assets.size(); i++) {
             auto asset = assets[i];
             if (!asset->CanFetch()) {
                 loaded = false;
@@ -805,7 +802,7 @@ public:
 
     int CountLoaded() {
         int loaded = 0;
-        for (int i = 0; i < assets.size(); i++) {
+        for (size_t i = 0; i < assets.size(); i++) {
             if (assets[i]->CanFetch()) {
                 loaded++;
             }
@@ -825,7 +822,7 @@ public:
         ZoneScoped
         while (!PollLoaded()) {
         }
-        for (int i = 0; i < assets.size(); i++) {
+        for (size_t i = 0; i < assets.size(); i++) {
             // This finalizes any assets that need it
             // We're blocking anyways so why not
             assets[i]->CheckForFetch();
@@ -834,7 +831,7 @@ public:
 
     void LoadImmediate() {
         ZoneScoped
-        for (int i = 0; i < assets.size(); i++) {
+        for (size_t i = 0; i < assets.size(); i++) {
             assets[i]->LoadImmediate();
             if (assets[i]->state == PREFINALIZED) {
                 assets[i]->CheckForFetch();

--- a/Encore/src/debug/EncoreDebug.cpp
+++ b/Encore/src/debug/EncoreDebug.cpp
@@ -154,7 +154,7 @@ void EncoreDebug::MenuBar() {
     auto size = CalcTextSize(debugVersionHash.c_str()).x;
 
     SetCursorPosX(avail - size - GetStyle().FramePadding.x);
-    Text(debugVersionHash.c_str());
+    Text("%s", debugVersionHash.c_str());
 
     EndMainMenuBar();
 }
@@ -200,7 +200,7 @@ void DebugSeek(float time, float audioTime) {
         auto player = ThePlayerManager.PlayerList[index];
         auto engine = player.engine.get();
         engine->chart->MissedNotePointers.clear();
-        for (int i = 0; i < engine->chart->CurrentNoteIterators.size(); i++) {
+        for (size_t i = 0; i < engine->chart->CurrentNoteIterators.size(); i++) {
             if (i >= engine->chart->Lanes.size()) {
                 break;
             }
@@ -220,8 +220,8 @@ void EncoreDebug::DrawPracticeSectionSelector() {
     ZoneScoped;
     if (TheMenuManager.currentScreen == GAMEPLAY) {
         if (Begin("Practice Section Selector")) {
-            for (int sectionInt = 0; sectionInt < TheSongTime.Sections.size(); sectionInt++) {
-                Text(TheSongTime.Sections.at(sectionInt).name.c_str());
+            for (size_t sectionInt = 0; sectionInt < TheSongTime.Sections.size(); sectionInt++) {
+                Text("%s", TheSongTime.Sections.at(sectionInt).name.c_str());
                 SameLine();
                 float buttWidth = CalcTextSize(" whole").x;
                 SetCursorPosX(GetWindowWidth() - (buttWidth * 3));
@@ -330,9 +330,9 @@ void EncoreDebug::DrawSongScrubber() {
                 }
                 return false;
             };
-            int layer = 0;
-            int maxlayer = 0;
-            for (int i = 0; i < TheSongTime.Sections.size(); i++) {
+            size_t layer = 0;
+            size_t maxlayer = 0;
+            for (size_t i = 0; i < TheSongTime.Sections.size(); i++) {
                 auto& section = TheSongTime.Sections[i];
                 float endTime = TheSongTime.GetSongLength();
                 if (i < TheSongTime.Sections.size() - 1) {
@@ -352,7 +352,7 @@ void EncoreDebug::DrawSongScrubber() {
                 }
                 float textY = pos.y + size.y + layer * GetFontSize();
                 drawlist->AddText(ImVec2(startPos+pos.x, textY), 0xffffffff, section.name.c_str());
-                texts.push_back({startPos, startPos+textWide, layer});
+                texts.push_back({startPos, startPos+textWide, static_cast<int>(layer)});
                 if (layer > maxlayer) {
                     maxlayer = layer;
                 }
@@ -463,7 +463,7 @@ void EncoreDebug::DrawSongList() {
     static auto UpdateList = [&] {
         songs.clear();
         std::string lowerFilter = tolowerStr(filter);
-        for (int i = 0; i < TheSongList.songs.size(); i++) {
+        for (size_t i = 0; i < TheSongList.songs.size(); i++) {
             auto song = &TheSongList.songs[i];
             if (filter.empty()) {
                 songs.push_back(song);
@@ -500,7 +500,7 @@ void EncoreDebug::DrawSongList() {
             TableSetupColumn("Source", ImGuiTableColumnFlags_WidthFixed);
             TableHeadersRow();
 
-            for (int i = 0; i < songs.size(); i++) {
+            for (size_t i = 0; i < songs.size(); i++) {
                 auto song = songs[i];
                 TableNextRow();
                 PushID(i);
@@ -578,17 +578,17 @@ void EncoreDebug::DrawAssetViewer() {
             TableHeadersRow();
 
             PushFont(GetIO().FontDefault, 16);
-            int i = 0;
+            size_t i = 0;
             for (auto asset : TheAssets.assets) {
                 TableNextRow();
                 PushID(i);
                 TableSetColumnIndex(1);
-                Text(
+                Text("%s",
                     std::filesystem::path(asset->id).filename().generic_string().c_str());
                 TableSetColumnIndex(2);
-                Text(typeid(*asset).name());
+                Text("%s", typeid(*asset).name());
                 TableSetColumnIndex(3);
-                Text(AssetStateName(asset->state));
+                Text("%s", AssetStateName(asset->state));
 
                 TableSetColumnIndex(0);
                 switch (asset->state) {
@@ -606,6 +606,8 @@ void EncoreDebug::DrawAssetViewer() {
                     if (SmallButton("Unload")) {
                         asset->Unload();
                     }
+                    break;
+                default:
                     break;
                 }
                 PopID();
@@ -661,21 +663,21 @@ void Encore::Track::DrawTrackDebugWindow() {
                                               countdown));
             };
             SeparatorText("Stats");
-            Text(TextFormat("Combo: %i", player.engine->stats->Combo));
-            Text(TextFormat("Ghost Count: %i", player.engine->GhostCount));
-            Text(TextFormat("Max combo: %i", player.engine->stats->MaxCombo));
-            Text(
+            Text("%s", TextFormat("Combo: %i", player.engine->stats->Combo));
+            Text("%s", TextFormat("Ghost Count: %i", player.engine->GhostCount));
+            Text("%s", TextFormat("Max combo: %i", player.engine->stats->MaxCombo));
+            Text("%s", 
                 TextFormat("Attempted notes: %i", player.engine->stats->AttemptedNotes)
             );
-            Text(TextFormat("Misses: %i", player.engine->stats->Misses));
-            Text(TextFormat("Notes hit: %i (%.0f%)",
+            Text("%s", TextFormat("Misses: %i", player.engine->stats->Misses));
+            Text("%s", TextFormat("Notes hit: %i (%.0f%)",
                                    player.engine->stats->NotesHit,
                                    (float)player.engine->stats->NotesHit / player.engine->
                                    stats->AttemptedNotes * 100));
-            Text(TextFormat("Score: %4.2f", player.engine->stats->Score));
-            Text(TextFormat("Base score: %4.2f", player.engine->chart->BaseScore));
-            Text(TextFormat("Stars: *%i", player.engine->stats->Stars));
-            Text(TextFormat("Multiplier: %ix",
+            Text("%s", TextFormat("Score: %4.2f", player.engine->stats->Score));
+            Text("%s", TextFormat("Base score: %4.2f", player.engine->chart->BaseScore));
+            Text("%s", TextFormat("Stars: *%i", player.engine->stats->Stars));
+            Text("%s", TextFormat("Multiplier: %ix",
                                    player.engine->stats->multiplier()));
             Checkbox("Allow Timestamped Inputs", &player.engine->allowTimestampedInputs);
         }

--- a/Encore/src/gameplay/enctime.cpp
+++ b/Encore/src/gameplay/enctime.cpp
@@ -3,10 +3,7 @@
 
 #include "settings/settings.h"
 #include "song/songlist.h"
-#include "util/enclog.h"
 
-#include <algorithm>
-#include <iostream>
 #include <cmath>
 #include "song/audio.h"
 
@@ -75,7 +72,7 @@ void SongTime::GenerateOverdriveTicks(smf::MidiFile &midiFile, int TrackID) {
 
     // todo: make this actually measure based potentially. this fucks over gh songs with non x/4 time sigs.
     if (OverdriveTicks.size() == 0) {
-        int overdriveTickCount = floor(midiFile.getFileDurationInTicks() / 480);
+        int overdriveTickCount = midiFile.getFileDurationInTicks() / 480;
         for (int i = 0; i < overdriveTickCount; i++) {
             OverdriveTicks.emplace_back(midiFile.getTimeInSeconds(480 * i), 480 * i);
         }

--- a/Encore/src/gameplay/enctime.h
+++ b/Encore/src/gameplay/enctime.h
@@ -67,16 +67,16 @@ private:
 
 public:
     std::vector<OverdriveTick> OverdriveTicks {};
-    int CurrentODTickItr;
+    size_t CurrentODTickItr;
     std::vector<BPM> BPMChanges {};
-    int CurrentBPM;
+    size_t CurrentBPM;
     std::vector<TimeSig> TimeSigChanges {};
-    int CurrentTimeSig;
+    size_t CurrentTimeSig;
     std::vector<Beatline> Beatlines {};
-    int CurrentBeatline;
+    size_t CurrentBeatline;
 
     std::vector<Section> Sections {};
-    int CurrentLyricPhrase = 0;
+    size_t CurrentLyricPhrase = 0;
     std::vector<Encore::RhythmEngine::EncLyricPhrase> Lyrics {};
 
     SongTime() = default;

--- a/Encore/src/gameplay/trackRenderer/GemTrackSlot.cpp
+++ b/Encore/src/gameplay/trackRenderer/GemTrackSlot.cpp
@@ -4,7 +4,7 @@
 #include "assets.h"
 #include "rlgl.h"
 
-#include <complex>
+#include "Track.h"
 
 #include "song/song.h"
 

--- a/Encore/src/gameplay/trackRenderer/GemTrackSlot.cpp
+++ b/Encore/src/gameplay/trackRenderer/GemTrackSlot.cpp
@@ -2,30 +2,30 @@
 #include "GemTrackSlot.h"
 
 #include "assets.h"
+#include "easing/easing.h"
 #include "rlgl.h"
 
 #include "Track.h"
 
 #include "song/song.h"
 
-float easeOutBounce(float x) {
-    const float n1 = 7.5625;
-    const float d1 = 2.75;
+// float easeOutBounce(float x) {
+//     const float n1 = 7.5625;
+//     const float d1 = 2.75;
 
-    if (x < 1 / d1) {
-        return n1 * x * x;
-    } else if (x < 2 / d1) {
-        return n1 * (x -= 1.5 / d1) * x + 0.75;
-    } else if (x < 2.5 / d1) {
-        return n1 * (x -= 2.25 / d1) * x + 0.9375;
-    } else {
-        return n1 * (x -= 2.625 / d1) * x + 0.984375;
-    }
-}
+//     if (x < 1 / d1) {
+//         return n1 * x * x;
+//     } else if (x < 2 / d1) {
+//         return n1 * (x -= 1.5 / d1) * x + 0.75;
+//     } else if (x < 2.5 / d1) {
+//         return n1 * (x -= 2.25 / d1) * x + 0.9375;
+//     } else {
+//         return n1 * (x -= 2.625 / d1) * x + 0.984375;
+//     }
+// }
 
 void Encore::GemTrackSlot::DrawNote(RhythmEngine::EncNote *note, bool missed) {
     auto pos = track->GetNotePos3D(note->StartSeconds);
-    float finalWidth = 1;
     Vector3 position = { xPos, 0.0, pos };
 
     // this is kinda nasty, just wanted a quick Thing
@@ -131,7 +131,7 @@ void Encore::GemTrackSlot::DrawSmasher(bool held) {
         overhitTimer = 0;
     }
 
-    float bounce = (1 - easeOutBounce(animTimer)) * 0.2;
+    float bounce = (1 - getEasingFunction(EaseOutBounce)(animTimer)) * 0.2;
 
     DrawModelEx(ASSET(smasherFrame),
                 { xPos, 0.025, 0 },

--- a/Encore/src/gameplay/trackRenderer/GemTrackSlot.h
+++ b/Encore/src/gameplay/trackRenderer/GemTrackSlot.h
@@ -1,6 +1,7 @@
 #ifndef ENCORE_GEMTRACKSLOT_H
 #define ENCORE_GEMTRACKSLOT_H
 #include "TrackSlot.h"
+#include "particles/ParticleSystem.h"
 
 namespace Encore {
 

--- a/Encore/src/gameplay/trackRenderer/KickTrackSlot.cpp
+++ b/Encore/src/gameplay/trackRenderer/KickTrackSlot.cpp
@@ -4,6 +4,7 @@
 
 #include "KickTrackSlot.h"
 
+#include "Track.h"
 #include "assets.h"
 #include "rlgl.h"
 
@@ -15,11 +16,14 @@ float easeOutBounceKick(float x) {
     if (x < 1 / d1) {
         return n1 * x * x;
     } else if (x < 2 / d1) {
-        return n1 * (x -= 1.5 / d1) * x + 0.75;
+        float old_x = x -= 1.5;
+        return n1 * (old_x / d1) * x + 0.75;
     } else if (x < 2.5 / d1) {
-        return n1 * (x -= 2.25 / d1) * x + 0.9375;
+        float old_x = x -= 2.25;
+        return n1 * (old_x / d1) * x + 0.9375;
     } else {
-        return n1 * (x -= 2.625 / d1) * x + 0.984375;
+        float old_x = x -= 2.625;
+        return n1 * (old_x / d1) * x + 0.984375;
     }
 }
 

--- a/Encore/src/gameplay/trackRenderer/KickTrackSlot.h
+++ b/Encore/src/gameplay/trackRenderer/KickTrackSlot.h
@@ -13,11 +13,11 @@ namespace Encore {
         KickTrackSlot(Track *track, float xPos, float width, ColorSlot colorSlot) : TrackSlot(track, xPos, width, colorSlot) {};
 
         float animTimer = 1;
-        virtual void DrawNote(RhythmEngine::EncNote *note, bool missed);
+        virtual void DrawNote(RhythmEngine::EncNote *note, bool missed) override;
         virtual void DrawSustainTail(double startTime, double endTime) override {};
-        virtual void DrawSmasher(bool held);
-        virtual void AnimateHit(bool perfect, Color color);
-        virtual void AnimateOverhit();
+        virtual void DrawSmasher(bool held) override;
+        virtual void AnimateHit(bool perfect, Color color) override;
+        virtual void AnimateOverhit() override;
     };
 }
 

--- a/Encore/src/gameplay/trackRenderer/OpenTrackSlot.cpp
+++ b/Encore/src/gameplay/trackRenderer/OpenTrackSlot.cpp
@@ -5,6 +5,7 @@
 #include "OpenTrackSlot.h"
 
 #include "assets.h"
+#include "Track.h"
 
 void Encore::OpenTrackSlot::DrawNote(RhythmEngine::EncNote *note, bool missed) {
     auto pos = track->GetNotePos3D(note->StartSeconds);

--- a/Encore/src/gameplay/trackRenderer/OpenTrackSlot.h
+++ b/Encore/src/gameplay/trackRenderer/OpenTrackSlot.h
@@ -15,10 +15,10 @@ namespace Encore {
             openHitAnim = true;
         };
 
-        virtual void DrawNote(RhythmEngine::EncNote *note, bool missed);
-        virtual void DrawSustainTail(double startTime, double endTime);
-        virtual void DrawSmasher(bool held) {};
-        virtual void AnimateHit(bool perfect, Color color) {};
+        virtual void DrawNote(RhythmEngine::EncNote *note, bool missed) override;
+        virtual void DrawSustainTail(double startTime, double endTime) override;
+        virtual void DrawSmasher(bool held) override {};
+        virtual void AnimateHit(bool perfect, Color color) override {};
     };
 
 }

--- a/Encore/src/gameplay/trackRenderer/Track.cpp
+++ b/Encore/src/gameplay/trackRenderer/Track.cpp
@@ -6,11 +6,11 @@
 
 #include "GemTrackSlot.h"
 #include "assets.h"
+#include "menus/uiUnits.h"
 #include "raylib.h"
 #include "raymath.h"
 #include "rlgl.h"
 #include "gameplay/enctime.h"
-#include "imgui.h"
 #include "KickTrackSlot.h"
 #include "OpenTrackSlot.h"
 #include "debug/EncoreDebug.h"
@@ -340,7 +340,7 @@ void Encore::Track::DrawTrackNotifications() {
         NotificationPoint,
         AnimCamera);
     float FontSize = u.hinpct(0.03f);
-    for (int i = 0; i < Notifications.size(); i++) {
+    for (size_t i = 0; i < Notifications.size(); i++) {
         if (!Notifications[i].isEvent) {
             continue;
         }
@@ -371,7 +371,6 @@ void Encore::Track::DrawCombo() {
     Units &u = Units::getInstance();
     Vector2 pos = {};
     Vector3 WorldMultiplierPosition = { 0, -0.1, -1.3 };
-    unsigned char alpha = 255;
     float FontSize = u.hinpct(0.025f);
     // float TextWidth = MeasureTextEx(ASSET(rubikBold), JudgementStr.c_str(), FontSize, 0).
     float TextHeight = MeasureTextEx(ASSET(rubikBold), std::to_string(player.engine->stats->Combo).c_str(), FontSize, 0).
@@ -517,7 +516,7 @@ void Encore::Track::DrawNotes() {
         return;
     }
 
-    for (int lane = 0; lane < player.engine->chart->Lanes.size(); lane++) {
+    for (size_t lane = 0; lane < player.engine->chart->Lanes.size(); lane++) {
         std::pair<int, int> NotePoolSize = player.engine->GetNotePoolSize(lane);
         for (int curNote = NotePoolSize.second - 1; curNote >= NotePoolSize.first; curNote
              --) {
@@ -563,7 +562,7 @@ void Encore::Track::DrawSmashers() {
     ZoneScoped;
     rlEnableDepthTest();
     glClear(GL_DEPTH_BUFFER_BIT);
-    for (int i = 0; i < slots.size(); i++) {
+    for (size_t i = 0; i < slots.size(); i++) {
         auto slot = slots.at(i).get();
         slot->DrawSmasher(
             slot->index < player.engine->stats->HeldFrets.size() && player.engine->stats->
@@ -579,7 +578,7 @@ void Encore::Track::DrawBeatlines() {
             TheSongTime.Beatlines.erase(TheSongTime.Beatlines.begin());
         }
 
-        int beatlinePoolMaxSize = NOTE_POOL_SIZE / 4;
+        size_t beatlinePoolMaxSize = NOTE_POOL_SIZE / 4;
         size_t BeatlinePoolSize = TheSongTime.Beatlines.size() > beatlinePoolMaxSize
             ? beatlinePoolMaxSize
             : TheSongTime.Beatlines.size();
@@ -623,7 +622,7 @@ void Encore::Track::DrawBeatlines() {
 Encore::TrackSlot **Encore::Track::GetSlotsForNote(RhythmEngine::EncNote &note) const {
     static TrackSlot *slotBuffer[7];
     int curIndex = 0;
-    auto append_slot = [&](int index) {
+    auto append_slot = [&](size_t index) {
         if (index >= slots.size()) {
             return;
         }
@@ -650,7 +649,7 @@ Encore::TrackSlot **Encore::Track::GetSlotsForNote(RhythmEngine::EncNote &note) 
 Encore::TrackSlot **Encore::Track::GetSlotsForLane(uint8_t lane, bool forceMask) const {
     static TrackSlot *slotBuffer[7];
     int curIndex = 0;
-    auto append_slot = [&](int index) {
+    auto append_slot = [&](size_t index) {
         if (index >= slots.size()) {
             return;
         }

--- a/Encore/src/gameplay/trackRenderer/TrackSlot.h
+++ b/Encore/src/gameplay/trackRenderer/TrackSlot.h
@@ -1,7 +1,7 @@
 
 #ifndef ENCORE_TRACKSLOT_H
 #define ENCORE_TRACKSLOT_H
-#include "Track.h"
+
 #include "RhythmEngine/Notes/EncNote.h"
 #include "raylib.h"
 #include "users/ColorProfile.h"
@@ -16,7 +16,7 @@ namespace Encore {
         float length;
         ColorSlot colorSlot;
         Track *track;
-        int index = 0;
+        size_t index = 0;
 
         float overhitTimer = 0.0;
         bool openHitAnim = false;

--- a/Encore/src/gameplay/trackRenderer/particles/ParticleSystem.cpp
+++ b/Encore/src/gameplay/trackRenderer/particles/ParticleSystem.cpp
@@ -2,6 +2,8 @@
 #include "ParticleSystem.h"
 
 #include "assets.h"
+#include "gameplay/trackRenderer/Track.h"
+
 void Encore::Particle::Update(ParticleSystem* system) {
     time += GetFrameTime();
     switch (type) {
@@ -15,6 +17,8 @@ void Encore::Particle::Update(ParticleSystem* system) {
         if (time > SHOCKWAVE_LIFETIME) {
             active = false;
         }
+        break;
+    default:
         break;
     }
 }
@@ -38,7 +42,7 @@ void Encore::Particle::Render(ParticleSystem* system) {
             float frac = (lifetime/FLARE_LIFETIME);
             color.a = (frac*frac)*255;
             Color white = {255, 255, 255, color.a};
-            Rectangle source = { 0.0f, 0.0f, (float)ASSET(hitFlareTex).width, (float)ASSET(hitFlareTex).height };
+            // Rectangle source = { 0.0f, 0.0f, (float)ASSET(hitFlareTex).width, (float)ASSET(hitFlareTex).height };
             float size = 2.4-time*0.5;
             BeginBlendMode(BlendMode::BLEND_ADDITIVE);
             //DrawBillboardRec(system->billboardCamera, ASSET(hitFlareTex), source, position, {size*0.9f, size*1.2f}, ColorLerp(color, white, 0));
@@ -63,6 +67,8 @@ void Encore::Particle::Render(ParticleSystem* system) {
             EndBlendMode();
             break;
         }
+        default:
+            break;
     }
 }
 

--- a/Encore/src/gameplay/trackRenderer/particles/ParticleSystem.h
+++ b/Encore/src/gameplay/trackRenderer/particles/ParticleSystem.h
@@ -7,7 +7,6 @@
 #define SHOCKWAVE_LIFETIME 0.3f
 
 #include "raylib.h"
-#include "../Track.h"
 
 namespace Encore {
 

--- a/Encore/src/menus/GameplayMenu.cpp
+++ b/Encore/src/menus/GameplayMenu.cpp
@@ -5,7 +5,6 @@
 #include "GameplayMenu.h"
 
 #include "gameMenu.h"
-#include "overshellRenderer.h"
 #include "uiUnits.h"
 #include "song/audio.h"
 #include "song/songlist.h"
@@ -17,9 +16,7 @@
 
 #include "users/playerManager.h"
 #include "MenuManager.h"
-#include "OvershellHelper.h"
 #include "../settings/settings.h"
-#include "timingvalues.h"
 
 #include <raylib.h>
 
@@ -203,7 +200,7 @@ void GameplayMenu::DrawGameplayStars(
     // todo: redo for band
     auto &player = ThePlayerManager.GetActivePlayer(0);
     int inst = player.Instrument % 5;
-    int diff = player.Difficulty;
+    // int diff = player.Difficulty;
     double starPercent = player.engine->stats->StarThresholdValue;
     int starsVal = player.engine->stats->Stars;
     for (int i = 0; i < 5; i++) {
@@ -305,8 +302,8 @@ void GameplayMenu::Draw() {
         TheAudioManager.BeginPlayback(TheAudioManager.loadedStreams[0].handle);
         songPlaying = true;
     }
-    std::array<Color, 5> grybo = { GREEN, RED, YELLOW, BLUE, ORANGE };
-    std::array<Color, 5> orybg = { ORANGE, RED, YELLOW, BLUE, GREEN };
+    // std::array<Color, 5> grybo = { GREEN, RED, YELLOW, BLUE, ORANGE };
+    // std::array<Color, 5> orybg = { ORANGE, RED, YELLOW, BLUE, GREEN };
     GameMenu::DrawAlbumArtBackground(TheSongList.curSong->albumArtBlur);
     DrawRectangle(0, 0, GetRenderWidth(), GetRenderHeight(), Color{ 0, 0, 0, 128 });
     DrawRectangle(
@@ -355,9 +352,9 @@ void GameplayMenu::Draw() {
         return;
     }
 
-    int denom = TheSongTime.TimeSigChanges.at(TheSongTime.CurrentTimeSig).denom;
-    int numer = TheSongTime.TimeSigChanges.at(TheSongTime.CurrentTimeSig).numer;
-    int flashInterval = (numer * 480) / denom;
+    // int denom = TheSongTime.TimeSigChanges.at(TheSongTime.CurrentTimeSig).denom;
+    // int numer = TheSongTime.TimeSigChanges.at(TheSongTime.CurrentTimeSig).numer;
+    // int flashInterval = (numer * 480) / denom;
 
     if (!TheSongTime.Lyrics.empty()) {
         ZoneScopedN("Lyrics Display")
@@ -369,7 +366,7 @@ void GameplayMenu::Draw() {
         float LyricLeft = 0;
         std::string playedText = "";
         std::string unplayedText = "";
-        Color lyricColor = WHITE;
+        // Color lyricColor = WHITE;
         auto font = ASSETPTR(rubikBold);
         for (const auto& lyric : TheSongTime.Lyrics.at(TheSongTime.CurrentLyricPhrase).lyrics) {
             if (lyric.StartSec < TheSongTime.GetElapsedTime()) {
@@ -384,7 +381,7 @@ void GameplayMenu::Draw() {
         // before i even CONSIDER going further with things like animations or fade or ANYTHING. this should be put somewhere but here.
         Rectangle imageRec {0, 0, float(ASSET(mainLyricBar).width), float(ASSET(mainLyricBar).height)};
         Rectangle dest {0, baselineVox, float(GetScreenWidth()), voxHeight};
-        LyricLeft += (GetScreenWidth() / 2) - (MeasureTextEx(*font, (playedText + unplayedText).c_str(), FontSize, 0).x / 2);
+        LyricLeft += int(GetScreenWidth() / 2) - (MeasureTextEx(*font, (playedText + unplayedText).c_str(), FontSize, 0).x / 2);
         DrawTexturePro(ASSET(mainLyricBar), imageRec, dest, {0, 0}, 0, WHITE);
         GameMenu::mhDrawText(*font, playedText, {LyricLeft, baselineVox + padding}, FontSize, {119,183,255,255}, ASSET(sdfShader), LEFT);
         LyricLeft += MeasureTextEx(*font, playedText.c_str(), FontSize, 0).x;
@@ -403,7 +400,7 @@ void GameplayMenu::Draw() {
             }
             imageRec = {0, 0, float(ASSET(secLyricBar).width), float(ASSET(secLyricBar).height)};
             dest = {0, topBelow, float(GetScreenWidth()), SecVoxSize};
-            LyricLeft = (GetScreenWidth() / 2) - (MeasureTextEx(*font, (lyricStr).c_str(), SecFontSize, 0).x / 2);
+            LyricLeft = int(GetScreenWidth() / 2) - (MeasureTextEx(*font, (lyricStr).c_str(), SecFontSize, 0).x / 2);
             DrawTexturePro(ASSET(secLyricBar), imageRec, dest, {0, 0}, 0, WHITE);
             GameMenu::mhDrawText(*font, lyricStr, {LyricLeft, topBelow + secPadding}, SecFontSize, LIGHTGRAY, ASSET(sdfShader), LEFT);
         }
@@ -427,20 +424,20 @@ void GameplayMenu::Draw() {
         }
 
         tracks.at(i)->Draw();
-        int TopOfScreen = GetRenderHeight(); // width
-        int FakeStrikeline = (TopOfScreen / 5) * 4;
-        constexpr int NoteXWidth = 150;
-        constexpr int NoteHeight = 25;
+        // int TopOfScreen = GetRenderHeight(); // width
+        // int FakeStrikeline = (TopOfScreen / 5) * 4;
+        // constexpr int NoteXWidth = 150;
+        // constexpr int NoteHeight = 25;
 
-        int mospos =
-            ((GetRenderWidth() + (ThePlayerManager.PlayersActive * NoteXWidth * 5))
-                / (1 + ThePlayerManager.PlayersActive))
-            - ((ThePlayerManager.PlayersActive * NoteXWidth * 5) / 2);
-        int MiddleOfScreen = mospos + (mospos * i); // height
-        int TrackLeft = MiddleOfScreen - (NoteXWidth / 2) - NoteXWidth - NoteXWidth;
+        // int mospos =
+        //     ((GetRenderWidth() + (ThePlayerManager.PlayersActive * NoteXWidth * 5))
+        //         / (1 + ThePlayerManager.PlayersActive))
+        //     - ((ThePlayerManager.PlayersActive * NoteXWidth * 5) / 2);
+        // int MiddleOfScreen = mospos + (mospos * i); // height
+        // int TrackLeft = MiddleOfScreen - (NoteXWidth / 2) - NoteXWidth - NoteXWidth;
         auto chart = player.engine->chart;
-        int SidesWidth = 20;
-        int RailWidth = SidesWidth / 2;
+        // int SidesWidth = 20;
+        // int RailWidth = SidesWidth / 2;
 
         if (player.engine.get()->stats.get()->AudioMuted) {
             int InstrumentNum =

--- a/Encore/src/menus/MenuManager.cpp
+++ b/Encore/src/menus/MenuManager.cpp
@@ -5,7 +5,6 @@
 #include "ReadyUpMenu.h"
 #include "SettingsAudioVideo.h"
 #include "SettingsController.h"
-#include "SettingsCredits.h"
 #include "SettingsGameplay.h"
 #include "SettingsKeyboard.h"
 #include "SettingsMenu.h"
@@ -18,7 +17,6 @@
 #include "settings/settings.h"
 #include "sndTestMenu.h"
 #include "gameplay/inputCallbacks.h"
-#include "song/audio.h"
 #include "users/playerManager.h"
 #include "util/discord.h"
 #include "tracy/Tracy.hpp"
@@ -199,7 +197,6 @@ void MenuManager::DrawMenu() {
                         totalDifference += (tapTime - expectedClickTime);
                     }
                     TheGameSettings.AudioOffset = 0;
-                        static_cast<int>((totalDifference / tapTimes.size()) * 1000);
                     // Convert to milliseconds
                     std::cout
                         << static_cast<int>((totalDifference / tapTimes.size()) * 1000)
@@ -248,7 +245,7 @@ void MenuManager::DrawMenu() {
                     assets.rubikBold,
                     "Input Registered",
                     { static_cast<float>((GetRenderWidth() - u.hinpct(0.35f)) / 2),
-                      static_cast<float>(GetRenderHeight() / 2) },
+                      static_cast<float>(int(GetRenderHeight() / 2)) },
                     u.hinpct(0.05f),
                     0,
                     feedbackColor

--- a/Encore/src/menus/ReadyUpMenu.cpp
+++ b/Encore/src/menus/ReadyUpMenu.cpp
@@ -20,7 +20,7 @@ void ReadyUpMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
         if (playerId == -1) continue;
         auto &player = ThePlayerManager.GetActivePlayer(i);
         if (player.joypadID != event.slot) continue;
-        if (event.slot == -1) return;
+        if (event.slot == std::numeric_limits<unsigned int>::max()) return;
         if (event.action == Encore::RhythmEngine::Action::PRESS) {
             switch (event.channel) {
             case Encore::RhythmEngine::InputChannel::STRUM_UP: {
@@ -35,6 +35,8 @@ void ReadyUpMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
 
                     if (ControllerDiffSlot[i] > 4) ControllerDiffSlot[i] = 4;
                     break;
+                default:
+                    break;
                 }
                 break;
             }
@@ -47,6 +49,8 @@ void ReadyUpMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
                 case DIFFICULTY:
                     ControllerDiffSlot[i]--;
                     if (ControllerDiffSlot[i] < 0) ControllerDiffSlot[i] = 0;
+                    break;
+                default:
                     break;
                 }
                 break;
@@ -61,6 +65,8 @@ void ReadyUpMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
                     SlotState[i] = READY;
                     player.Difficulty = ControllerDiffSlot[i];
                     ReadyState[i] = true;
+                    break;
+                default:
                     break;
                 }
                 break;
@@ -81,6 +87,8 @@ void ReadyUpMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
                     break;
                 }
             }
+            default:
+                break;
             }
         }
     }
@@ -244,7 +252,7 @@ void ReadyUpMenu::Draw() {
                 break;
             }
 
-            for (int i = 0; i < PartsToDisplay[playerInt].size(); i++) {
+            for (size_t i = 0; i < PartsToDisplay[playerInt].size(); i++) {
                 if (ControllerInstSlot[playerInt] >= PartsToDisplay[playerInt].size()) {
                     ControllerInstSlot[playerInt] = PartsToDisplay[playerInt].size() - 1;
                 }
@@ -416,7 +424,7 @@ void ReadyUpMenu::Load() {
     for (int playerInt = 0; playerInt < 4; playerInt++) {
         if (ThePlayerManager.ActivePlayers[playerInt] == -1)
             continue;
-        for (int i = 0; i < TheSongList.curSong->parts.size(); i++) {
+        for (size_t i = 0; i < TheSongList.curSong->parts.size(); i++) {
             if (TheSongList.curSong->parts[i]->Valid) {
                 PartsToDisplay[playerInt].push_back(i);
             }

--- a/Encore/src/menus/ReadyUpMenu.h
+++ b/Encore/src/menus/ReadyUpMenu.h
@@ -16,8 +16,8 @@ class ReadyUpMenu : public OvershellMenu {
 
     std::array<ReadyUpMenuState, 4> SlotState{ INSTRUMENT, INSTRUMENT, INSTRUMENT, INSTRUMENT };
     std::array<bool, 4> ReadyState{ false, false, false, false };
-    std::array<int, 4> ControllerDiffSlot{ 0, 0, 0, 0 };
-    std::array<int, 4> ControllerInstSlot{ 0, 0, 0, 0 };
+    std::array<uint8_t, 4> ControllerDiffSlot{ 0, 0, 0, 0 };
+    std::array<uint8_t, 4> ControllerInstSlot{ 0, 0, 0, 0 };
 
     std::array<std::vector<int>, 4> PartsToDisplay = {};
 public:

--- a/Encore/src/menus/SettingsController.cpp
+++ b/Encore/src/menus/SettingsController.cpp
@@ -205,21 +205,21 @@ void SettingsController::Draw() {
     DrawTextEx(assets.rubik, "Settings", {TextPlacementLR, u.hpct(0.027f)}, u.hinpct(0.042f), 0, LIGHTGRAY);
     GameMenu::mhDrawText(assets.redHatDisplayBlack, "CONTROLLER BINDINGS", {TextPlacementLR, TextPlacementTB}, u.hinpct(0.125f), WHITE, assets.sdfShader, LEFT);
 
-    float settingsOffsetX = 0.0f;
-    float EntryFontSize = u.hinpct(0.03f);
-    float EntryHeight = u.hinpct(0.06f) + 30.0f - 50.0f + 10.0f + 7.0f;
-    float EntryTop = TextPlacementTB + u.hinpct(0.15f);
-    float verticalGap = 0.0f;
-    float boxLeft = u.LeftSide + u.winpct(0.025f) + settingsOffsetX + 75.0f - 50.0f - 2.0f;
-    float boxWidth = u.wpct(boxWidthPct) + 50.0f + 17.0f + 7.0f - 2.0f - 2.0f;
-    float OptionLeft = boxLeft;
-    float OptionWidth = boxWidth;
-    Color boxBackground = Color{31, 31, 50, 255};
-    Color boxBorder = WHITE;
-    Color glowColor = Color{142, 13, 148, 220};
-    float highlightBorderWidth = 4.0f;
+    // float settingsOffsetX = 0.0f;
+    // float EntryFontSize = u.hinpct(0.03f);
+    // float EntryHeight = u.hinpct(0.06f) + 30.0f - 50.0f + 10.0f + 7.0f;
+    // float EntryTop = TextPlacementTB + u.hinpct(0.15f);
+    // float verticalGap = 0.0f;
+    // float boxLeft = u.LeftSide + u.winpct(0.025f) + settingsOffsetX + 75.0f - 50.0f - 2.0f;
+    // float boxWidth = u.wpct(boxWidthPct) + 50.0f + 17.0f + 7.0f - 2.0f - 2.0f;
+    // float OptionLeft = boxLeft;
+    // float OptionWidth = boxWidth;
+    // Color boxBackground = Color{31, 31, 50, 255};
+    // Color boxBorder = WHITE;
+    // Color glowColor = Color{142, 13, 148, 220};
+    // float highlightBorderWidth = 4.0f;
 
-    Vector2 mousePos = GetMousePosition();
+    // Vector2 mousePos = GetMousePosition();
     isHovering = false;
     /*
     TraceLog(LOG_INFO, "Rendering %zu controller entries", options.size());

--- a/Encore/src/menus/SettingsMenu.cpp
+++ b/Encore/src/menus/SettingsMenu.cpp
@@ -8,11 +8,8 @@
 #include "gameMenu.h"
 #include "raygui.h"
 #include "settings/settings.h"
-#include "settingsOptionRenderer.h"
 #include "uiUnits.h"
-#include "gameplay/enctime.h"
 #include "assets.h"
-#include "OvershellMenu.h"
 #include "util/settings-text.h"
 #include "OvershellHelper.h"
 
@@ -27,9 +24,6 @@ enum OptionsCategories {
 void SettingsMenu::Draw() {
     Units &u = Units::getInstance();
     Assets &assets = Assets::getInstance();
-    // SettingsOld &settingsMain = SettingsOld::getInstance();
-    SongTime &enctime = TheSongTime;
-    settingsOptionRenderer sor;
     encOS::DrawTopOvershell(0.15f);
     if (TheSongList.curSong != nullptr)
         GameMenu::DrawAlbumArtBackground(TheSongList.curSong->albumArtBlur);

--- a/Encore/src/menus/SongSelectMenu.cpp
+++ b/Encore/src/menus/SongSelectMenu.cpp
@@ -70,6 +70,8 @@ void SongSelectMenu::ControllerInputCallback(
                 TheMenuManager.SwitchScreen(READY_UP);
             }
             break;
+        default: 
+            break;
         }
     }
     TheSongList.curSong = &TheSongList.songs[TheSongList.listMenuEntries[curSongMenuPos].songListID];
@@ -371,7 +373,7 @@ void SongSelectMenu::Draw() {
         ColorBrightness(AccentColor, -0.75f)
     );
     int topOflistMenu = curSongMenuPos <= 4 ? 1 : curSongMenuPos - 4;
-    for (int listMenuPos = topOflistMenu;
+    for (size_t listMenuPos = topOflistMenu;
          listMenuPos < TheSongList.listMenuEntries.size() &&
          (listMenuPos < curSongMenuPos + (topOflistMenu <= 4 ? 10 : 6));
          listMenuPos++) {
@@ -502,7 +504,7 @@ void SongSelectMenu::Draw() {
     if (curSongMenuPos > 0 && curSongMenuPos < TheSongList.
         listMenuEntries.size()) {
         std::string categoryHeaderText = "";
-        int songIndex = curSongMenuPos;
+        size_t songIndex = curSongMenuPos;
 
         if (TheSongList.listMenuEntries[songIndex].isHeader && songIndex > 0 && !
             TheSongList.listMenuEntries[songIndex - 1].isHeader) {
@@ -760,7 +762,7 @@ void SongSelectMenu::Draw() {
     )) {
         //todo: I BROKE THE SORT BUTTON LMFAO
         // no i didnt
-        int selectedSongIndex = -1;
+        size_t selectedSongIndex = -1;
         if (TheSongList.curSong) {
             for (size_t i = 0; i < TheSongList.songs.size(); i++) {
                 if (&TheSongList.songs[i] == TheSongList.curSong) {

--- a/Encore/src/menus/SongSelectMenu.h
+++ b/Encore/src/menus/SongSelectMenu.h
@@ -5,8 +5,6 @@
 #ifndef SONGSELECTMENU_H
 #define SONGSELECTMENU_H
 #include "OvershellMenu.h"
-#include <filesystem>
-#include <map>
 
 class SongSelectMenu : public OvershellMenu {
 public:
@@ -27,7 +25,7 @@ private:
     const float previewPlayDuration = 30.0f;
     const float pauseDuration = 2.5f;
     double phaseStartTime = 0.0;
-    int curSongMenuPos = -1;
+    size_t curSongMenuPos = -1;
     double curTime = 0.0;
     double selectionTime = 0.0;
 };

--- a/Encore/src/menus/resultsMenu.cpp
+++ b/Encore/src/menus/resultsMenu.cpp
@@ -7,7 +7,6 @@
 #include "raygui.h"
 #include "styles.h"
 #include "uiUnits.h"
-#include "song/audio.h"
 #include "users/playerManager.h"
 #include "OvershellHelper.h"
 #include "MenuManager.h"
@@ -16,7 +15,7 @@ void resultsMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
 
     if (event.action == Encore::RhythmEngine::Action::PRESS) {
         switch (event.channel) {
-        case Encore::RhythmEngine::InputChannel::LANE_1:
+        case Encore::RhythmEngine::InputChannel::LANE_1: {
             for (int i = 0; i < ThePlayerManager.PlayersActive; i++) {
                 Player &player = ThePlayerManager.GetActivePlayer(i);
                 player.engine->stats.reset();
@@ -24,6 +23,8 @@ void resultsMenu::ControllerInputCallback(Encore::RhythmEngine::ControllerEvent 
                 player.engine.reset();
             }
             TheMenuManager.SwitchScreen(SONG_SELECT);
+        } break;
+        default:
             break;
         }
     }

--- a/Encore/src/song/song.h
+++ b/Encore/src/song/song.h
@@ -6,14 +6,10 @@
 #include "raylib.h"
 #include "midifile/MidiFile.h"
 #include <vector>
-#include <iostream>
-#include <fstream>
 #include <unordered_map>
 #include <filesystem>
-#include <cmath>
 #include <string>
 #include <atomic>
-#include "picosha2.h"
 #include "inih/INIReader.h"
 #include "tracy/Tracy.hpp"
 #include "util/enclog.h"
@@ -307,7 +303,7 @@ public:
 
     // Coda BRE {};
     void getCodas(smf::MidiFile &midiFile) {
-        int codaCount = 0;
+        // int codaCount = 0;
         for (int track = 0; track < midiFile.getTrackCount(); track++) {
             std::string trackName;
             for (int events = 0; events < midiFile[track].getSize(); events++) {

--- a/Encore/src/song/songlist.cpp
+++ b/Encore/src/song/songlist.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 #include <fstream>
+#include <sstream>
 #include "util/binary.h"
 
 using json = nlohmann::json;
@@ -332,7 +333,7 @@ void SongList::LoadCache(const std::vector<std::filesystem::path> &songsFolder) 
     std::set<std::string> loadedSongs; // To track loaded songs and avoid duplicates
     songs.reserve(cachedSongCount);
     MaxChartsToLoad = cachedSongCount;
-    for (int i = 0; i < cachedSongCount; i++) {
+    for (size_t i = 0; i < cachedSongCount; i++) {
         ZoneScopedN("Song")
         CurrentChartNumber = i + 1;
         Song song;
@@ -371,7 +372,7 @@ void SongList::LoadCache(const std::vector<std::filesystem::path> &songsFolder) 
     }
 
     SongCacheIn.close();
-    size_t loadedSongCount = songs.size();
+    // size_t loadedSongCount = songs.size();
 
 
     //if (cachedSongCount != loadedSongCount || songs.size() != loadedSongCount) {

--- a/Encore/src/song/songlist.cpp
+++ b/Encore/src/song/songlist.cpp
@@ -112,7 +112,7 @@ void SongList::sortList(SortType sortType) {
     listMenuEntries = GenerateSongEntriesWithHeaders(songs, sortType);
 }
 
-void SongList::sortList(SortType sortType, int &selectedSong) {
+void SongList::sortList(SortType sortType, size_t &selectedSong) {
     Song* curSong;
     bool hasCurrentSong = selectedSong >= 0 && selectedSong < songs.size();
     if (hasCurrentSong) {

--- a/Encore/src/song/songlist.h
+++ b/Encore/src/song/songlist.h
@@ -90,7 +90,7 @@ public:
     void sortList(SortType sortType);
 
     // for when you have a song selected and want to keep that position in song list
-    void sortList(SortType sortType, int &selectedSong);
+    void sortList(SortType sortType, size_t &selectedSong);
 
     void WriteCache();
 

--- a/Encore/src/users/playerManager.cpp
+++ b/Encore/src/users/playerManager.cpp
@@ -74,7 +74,7 @@ newPlayer.name = jsonObject.value().at(key).get<type>();
 }; // make player, load player stuff to PlayerList
 
 void PlayerManager::SavePlayerList() {
-    for (int i = 0; i < PlayerList.size(); i++) {
+    for (size_t i = 0; i < PlayerList.size(); i++) {
         SaveSpecificPlayer(i, false);
     }
 }; // ough this is gonna be complicated
@@ -124,7 +124,7 @@ void PlayerManager::SaveSpecificPlayer(const int slot, bool active) {
     Encore::WriteJsonFile(PlayerListSaveFile, PlayerListJson);
 }
 Player *PlayerManager::GetPlayerForJoystick(SDL_JoystickID id) {
-    for (int i = 0; i < ActivePlayers.size(); i++) {
+    for (size_t i = 0; i < ActivePlayers.size(); i++) {
         auto player = ActivePlayers[i];
         if (player == -1) {
             continue;
@@ -144,7 +144,7 @@ void PlayerManager::CreatePlayer(const std::string &name) {
 }; // set it as the next one in PlayerList
 
 void PlayerManager::DeletePlayer(const Player &PlayerToDelete) {
-    for (int i = 0; i < ActivePlayers.size(); i++) {
+    for (size_t i = 0; i < ActivePlayers.size(); i++) {
         auto player = ActivePlayers[i];
         if (player == -1) {
             continue;

--- a/Encore/src/users/playerManager.h
+++ b/Encore/src/users/playerManager.h
@@ -5,6 +5,7 @@
 
 #include "player.h"
 #include "util/discord.h"
+#include "util/enclog.h"
 
 class PlayerManager {
 public:
@@ -67,6 +68,8 @@ public:
         // WE'RE GONNA CRASH
         // WE'RE GONNA CRASH
         // WE'RE GONNA CRASH
+        Encore::EncoreLog(LOG_ERROR, "GetPlayerGamepad called. Get ready to have a headache.");
+        return *PlayerList.data();
     }
 
     void CreatePlayer(const std::string &name);


### PR DESCRIPTION
most of the complaints were about signage (`int i = 0; i < container.size()` being the usual suspect), but there were some un`default`ed switches and some header bleed too. also playermanager actually tells you that it's dying so no weird UB happens