### PR TITLE
docs(charts): fix PAD track name for Drums row

### DIFF
--- a/CHARTS.md
+++ b/CHARTS.md
@@ -18,7 +18,7 @@ This is a regular CH/RB midi file. Any 5-fret/Classic chart should be in a track
 | Bass/Groove | `PART_BASS`  | `PAD_BASS`  |
 | Vocals*     | `PART_VOCALS` | `PAD_VOCALS` |
 | Keys        | `PART_KEYS`  | `PAD_KEYS`  |
-| Drums**     | `PART_DRUMS`  | `PAD_KEYS`   |  
+| Drums**     | `PART_DRUMS`  | `PAD_DRUMS`  |  
 *Only supports lyrics display at the moment  
 **Only supports 4 lane/Pro drums
 


### PR DESCRIPTION
## Summary

Closes #85. `CHARTS.md:21` listed the pad-track name for the Drums row as `PAD_KEYS`, copy-pasted from the Keys row above. The convention from line 11 (`All PAD_<inst> tracks should be formatted for Encore pad gameplay`) and the other rows in the table (`PAD_GUITAR`, `PAD_BASS`, `PAD_VOCALS`, `PAD_KEYS` for Keys) means the Drums row should reference `PAD_DRUMS`.

## Why this matters

The CHARTS.md table is the chart-author reference for how to name tracks in CH/RB midi files. If a charter follows the Drums row literally they get `PAD_KEYS` named two places (once for Keys, once for Drums), which collides and breaks the pad-gameplay tooling that expects unique `PAD_<inst>` names.

## How to test

```
$ grep -nE "PAD_[A-Z]+" CHARTS.md | head -10
17:| Guitar/Lead | `PART_GUITAR` | `PAD_GUITAR` |
18:| Bass/Groove | `PART_BASS`  | `PAD_BASS`  |
19:| Vocals*     | `PART_VOCALS` | `PAD_VOCALS` |
20:| Keys        | `PART_KEYS`  | `PAD_KEYS`  |
21:| Drums**     | `PART_DRUMS`  | `PAD_DRUMS`  |
```

Fixes #85

AI-assisted.
